### PR TITLE
Add portable MCP introspection mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+**
+!mcp_server/
+!mcp_server/pyproject.toml
+!mcp_server/LICENSE
+!mcp_server/README.md
+!mcp_server/MANIFEST.in
+!mcp_server/multisim_mcp/
+!mcp_server/multisim_mcp/*.py
+!mcp_server/multisim_mcp/templates/
+!mcp_server/multisim_mcp/templates/manifest.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,48 @@ jobs:
           '@ | python -
       - name: Compile release audit and local-pack tools
         run: python -m compileall tools/release_audit.py tools/bootstrap_local_component_pack.py tools/extract_native_component_templates.py
+
+  linux-introspection:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+      - name: Build introspection-only image
+        run: docker build --tag multisim-mcp-glama .
+      - name: Verify Linux runtime diagnostics
+        run: |
+          docker run --rm -i multisim-mcp-glama python - <<'PY'
+          from multisim_mcp.multisim_client import runtime_diagnostics
+
+          result = runtime_diagnostics()
+          assert result["windows"] is False
+          assert result["runtime_compatible"] is False
+          assert result["runtime_mode"] == "introspection-only"
+          print(result)
+          PY
+      - name: Verify MCP initialize and tool introspection through Docker stdio
+        run: |
+          python -m pip install "mcp>=1.2.0,<2"
+          python - <<'PY'
+          import asyncio
+          from mcp import ClientSession, StdioServerParameters
+          from mcp.client.stdio import stdio_client
+
+          async def main():
+              params = StdioServerParameters(
+                  command="docker",
+                  args=["run", "--rm", "-i", "multisim-mcp-glama"],
+              )
+              async with stdio_client(params) as (read, write):
+                  async with ClientSession(read, write) as session:
+                      await session.initialize()
+                      response = await session.list_tools()
+              names = {tool.name for tool in response.tools}
+              assert "runtime_status" in names
+              assert "run_circuit_experiment" in names
+              print(f"Introspection returned {len(names)} tools")
+
+          asyncio.run(main())
+          PY

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -22,9 +22,9 @@ jobs:
           import json
           import urllib.request
 
-          with urllib.request.urlopen("https://pypi.org/pypi/multisim-mcp/0.1.0a1/json") as response:
+          with urllib.request.urlopen("https://pypi.org/pypi/multisim-mcp/0.1.0a2/json") as response:
               package = json.load(response)
-          assert package["info"]["version"] == "0.1.0a1"
+          assert package["info"]["version"] == "0.1.0a2"
           assert "mcp-name: io.github.yxy050208/multisim-mcp" in package["info"]["description"]
           PY
       - name: Install verified MCP Publisher v1.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 本项目遵循语义化版本的预发布形式。中文为主要说明，英文摘要紧随其后。
 
+## [0.1.0-alpha.2] - 2026-08-09
+
+### 中文
+
+- 增加 Linux/Docker `introspection-only` 模式，可完成 MCP 初始化和工具发现。
+- 将 `pywin32` 限定为 Windows 依赖；非 Windows 自动化调用返回明确兼容性提示。
+- 增加最小权限 Glama 验证镜像、严格 Docker 构建上下文和 Ubuntu 容器握手 CI。
+- 实际 Multisim 电路生成、仿真和导出仍仅支持本地 Windows + 32 位 Python。
+
+### English
+
+- Added a Linux/Docker `introspection-only` mode for MCP initialization and
+  tool discovery.
+- Made `pywin32` Windows-specific and added explicit diagnostics for unsupported
+  automation runtimes.
+- Added a least-privilege Glama validation image, a strict Docker build context,
+  and an Ubuntu container handshake check.
+- Real Multisim generation, simulation, and export remain Windows-only.
+
 ## [0.1.0-alpha] - 2026-08-09
 
 ### 中文

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Glama and registry introspection image. Real Multisim automation remains
+# Windows-only and requires a locally licensed Multisim installation.
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY mcp_server/pyproject.toml mcp_server/LICENSE mcp_server/README.md mcp_server/MANIFEST.in ./mcp_server/
+COPY mcp_server/multisim_mcp ./mcp_server/multisim_mcp
+
+RUN python -m pip install --no-cache-dir ./mcp_server \
+    && useradd --create-home --uid 10001 mcp
+
+USER mcp
+
+CMD ["multisim-mcp"]

--- a/README.en.md
+++ b/README.en.md
@@ -6,13 +6,13 @@ An unofficial local MCP server that lets an AI agent generate editable NI
 Multisim circuits from constrained SPICE input, run experiments, export data,
 and create reproducible reports.
 
-> Current target: `v0.1.0-alpha`. This project is not affiliated with or
+> Current target: `v0.1.0-alpha.2`. This project is not affiliated with or
 > endorsed by NI. A locally installed and licensed Multisim 14+ environment is
 > required. The current COM worker uses 32-bit Python.
 
 [PyPI package](https://pypi.org/project/multisim-mcp/) ·
 [Official MCP Registry entry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.yxy050208%2Fmultisim-mcp) ·
-[GitHub Release](https://github.com/yxy050208/multisim-mcp/releases/tag/v0.1.0-alpha)
+[GitHub Release](https://github.com/yxy050208/multisim-mcp/releases/tag/v0.1.0-alpha.2)
 
 ## End-to-end workflow
 
@@ -73,9 +73,16 @@ See the [publishing guide](docs/PUBLISHING.md) and
 Install the published package into a 32-bit Python environment:
 
 ```powershell
-C:\path\to\python32\python.exe -m pip install "multisim-mcp==0.1.0a1"
+C:\path\to\python32\python.exe -m pip install "multisim-mcp==0.1.0a2"
 C:\path\to\python32\Scripts\multisim-mcp.exe
 ```
+
+Linux and Docker provide MCP tool discovery and compatibility diagnostics only;
+they cannot run Multisim simulations. `runtime_status` reports
+`introspection-only` in the container, while every COM automation capability
+continues to require the Windows environment described above. The root
+`Dockerfile` exists for registries such as Glama to validate the protocol and
+tool definitions.
 
 To build a user-local component pack, install from source and run:
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 让 AI Agent 根据实验要求自动生成 Multisim 电路、运行仿真、提取实验数据，并导出
 电路图、CSV、波形图和实验报告。
 
-> 当前版本定位为 `v0.1.0-alpha`。项目非 NI 官方产品，需要本机安装并授权
+> 当前版本定位为 `v0.1.0-alpha.2`。项目非 NI 官方产品，需要本机安装并授权
 > Multisim 14+；当前 COM 运行时使用 32 位 Python。
 
 [PyPI 安装包](https://pypi.org/project/multisim-mcp/) ·
 [官方 MCP Registry 条目](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.yxy050208%2Fmultisim-mcp) ·
-[GitHub Release](https://github.com/yxy050208/multisim-mcp/releases/tag/v0.1.0-alpha)
+[GitHub Release](https://github.com/yxy050208/multisim-mcp/releases/tag/v0.1.0-alpha.2)
 
 ## 开源发布状态
 
-`0.1.0a1` 已发布到 PyPI，并以 `io.github.yxy050208/multisim-mcp` 收录到官方
+`0.1.0a2` 已发布到 PyPI，并以 `io.github.yxy050208/multisim-mcp` 收录到官方
 MCP Registry。由本地 NI 样例提取的 XML 模板不属于
 MIT 代码授权范围，公开仓库默认不应包含这些文件。用户需要运行
 `tools/bootstrap_local_component_pack.py`，从自己已授权的 Multisim 安装生成本地模板包。
@@ -64,9 +64,13 @@ MIT 代码授权范围，公开仓库默认不应包含这些文件。用户需�
 从 PyPI 安装到 32 位 Python 环境：
 
 ```powershell
-C:\path\to\python32\python.exe -m pip install "multisim-mcp==0.1.0a1"
+C:\path\to\python32\python.exe -m pip install "multisim-mcp==0.1.0a2"
 C:\path\to\python32\Scripts\multisim-mcp.exe
 ```
+
+Linux/Docker 仅提供 MCP 工具发现和兼容性诊断，不能运行 Multisim 仿真。容器中的
+`runtime_status` 会返回 `introspection-only`；所有 COM 自动化能力仍要求上述 Windows
+环境。根目录 `Dockerfile` 用于 Glama 等目录验证 MCP 协议和工具定义。
 
 从源码安装并生成本地元件模板包：
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -35,3 +35,13 @@
 
 The current Git index predates this checklist. Review staged files explicitly;
 adding an ignore rule does not remove a file that is already staged.
+
+## Required before v0.1.0-alpha.2
+
+- [ ] Verify Windows COM-free tests and package boundary checks.
+- [ ] Build the Linux validation image from the allowlisted Docker context.
+- [ ] Complete MCP initialize and `tools/list` through container stdio.
+- [ ] Confirm `runtime_status` reports `introspection-only` on Linux.
+- [ ] Publish `0.1.0a2` to PyPI and update the official MCP Registry.
+- [ ] Verify GitHub Release assets match the canonical PyPI SHA-256 hashes.
+- [ ] Add the Glama score badge to the awesome-mcp-servers submission.

--- a/docs/RELEASE_NOTES_v0.1.0-alpha.2.md
+++ b/docs/RELEASE_NOTES_v0.1.0-alpha.2.md
@@ -1,0 +1,36 @@
+# Multisim MCP v0.1.0-alpha.2
+
+[PyPI](https://pypi.org/project/multisim-mcp/0.1.0a2/) ·
+[官方 MCP Registry / Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.yxy050208%2Fmultisim-mcp) ·
+[源代码 / Source](https://github.com/yxy050208/multisim-mcp/tree/v0.1.0-alpha.2)
+
+## 中文（主要说明）
+
+这个 Alpha 增量版本为 MCP 目录和客户端增加了诚实的跨平台工具发现能力：
+
+- Linux/Docker 可以启动 MCP、完成初始化并列出工具；
+- `runtime_status` 在容器中明确返回 `introspection-only`；
+- `pywin32` 仅在 Windows 安装；
+- 所有 Multisim COM 操作在不兼容平台上都会立即返回清晰错误；
+- 新增非 root Glama 验证镜像、最小 Docker 构建上下文和 Ubuntu 容器握手 CI。
+
+容器不包含 NI 软件、样例、许可证或本地提取模板，也不能执行 Multisim 仿真。
+真实电路生成、实验和导出仍要求本地授权 Multisim 14+ 与 32 位 Windows Python。
+
+Windows 安装：
+
+```powershell
+C:\path\to\python32\python.exe -m pip install "multisim-mcp==0.1.0a2"
+```
+
+## English summary
+
+This incremental alpha adds an honest cross-platform discovery mode for MCP
+registries and clients. The Linux container starts the real stdio server,
+completes MCP initialization, and exposes tool schemas, while diagnostics label
+the runtime as `introspection-only`. COM-backed operations continue to fail
+closed unless the server runs under 32-bit Python on Windows with a licensed
+local Multisim installation.
+
+The validation image contains no NI software, samples, licenses, or extracted
+templates and does not claim to run Multisim simulations.

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -11,6 +11,13 @@ Multisim 执行实验，并导出 `.ms14`、原理图、raw、CSV、SVG 和 Mark
 > Alpha software. This project is not affiliated with NI. Multisim must be
 > installed and licensed locally. The current COM worker requires 32-bit Python.
 
+Linux and Docker support MCP initialization, tool discovery, and
+`runtime_status` diagnostics only. They do not run Multisim. On an unsupported
+platform the server starts in `introspection-only` mode, while every COM-backed
+operation fails closed with a Windows compatibility message. The repository's
+minimal non-root Docker image exists for registry validation and contains no NI
+software, samples, licenses, or extracted templates.
+
 ## Current capability
 
 Stable and verified on Multisim 14.3:

--- a/mcp_server/multisim_mcp/__init__.py
+++ b/mcp_server/multisim_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Unofficial Multisim MCP server."""
 
-__version__ = "0.1.0a1"
+__version__ = "0.1.0a2"

--- a/mcp_server/multisim_mcp/multisim_client.py
+++ b/mcp_server/multisim_mcp/multisim_client.py
@@ -17,9 +17,15 @@ import time
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
-import pythoncom
-import win32com.client
-import win32com.client.gencache
+try:
+    import pythoncom as _pythoncom
+    from win32com import client as _win32_client
+except ImportError:
+    _pythoncom = None
+    _win32_client = None
+
+pythoncom: Any = _pythoncom
+win32_client: Any = _win32_client
 
 from multisim_mcp import __version__
 from multisim_mcp.safety import NPX_DOWNLOAD_ENV, env_flag
@@ -32,16 +38,27 @@ CODEC_PACKAGE = "electronics-workbench-decoder@0.2.0"
 def runtime_diagnostics() -> dict:
     """Return actionable runtime details without starting Multisim."""
     bits = struct.calcsize("P") * 8
+    windows = os.name == "nt"
+    pywin32_available = pythoncom is not None and win32_client is not None
+    runtime_compatible = windows and bits == 32 and pywin32_available
     return {
         "platform": platform.platform(),
-        "windows": os.name == "nt",
+        "windows": windows,
         "python": sys.version.split()[0],
         "multisim_mcp": __version__,
         "python_executable": sys.executable,
         "python_bits": bits,
         "required_python_bits": 32,
+        "pywin32_available": pywin32_available,
         "prog_id": PROG_ID,
-        "runtime_compatible": os.name == "nt" and bits == 32,
+        "runtime_compatible": runtime_compatible,
+        "runtime_mode": "automation" if runtime_compatible else "introspection-only",
+        "runtime_message": (
+            "Multisim automation is available."
+            if runtime_compatible
+            else "MCP introspection is available, but Multisim automation requires "
+            "32-bit Python with pywin32 on Windows and a licensed Multisim installation."
+        ),
     }
 
 
@@ -54,6 +71,11 @@ def require_compatible_runtime() -> None:
         raise RuntimeError(
             "Multisim automation requires a 32-bit Python interpreter; "
             f"current interpreter is {info['python_bits']}-bit: {info['python_executable']}"
+        )
+    if not info["pywin32_available"]:
+        raise RuntimeError(
+            "Multisim automation requires pywin32; reinstall multisim-mcp in the "
+            "32-bit Windows Python environment"
         )
 
 
@@ -68,13 +90,15 @@ def clean_error(text: str) -> str:
 
 
 def bstr_array(values: Iterable[str]) -> Any:
-    return win32com.client.VARIANT(
+    require_compatible_runtime()
+    return win32_client.VARIANT(
         pythoncom.VT_ARRAY | pythoncom.VT_BSTR, list(values)
     )
 
 
 def r8_array(values: Iterable[float]) -> Any:
-    return win32com.client.VARIANT(
+    require_compatible_runtime()
+    return win32_client.VARIANT(
         pythoncom.VT_ARRAY | pythoncom.VT_R8, list(values)
     )
 
@@ -85,6 +109,7 @@ class MultisimClient:
         self._circuit: Any = None
 
     def _ensure_com(self) -> None:
+        require_compatible_runtime()
         try:
             pythoncom.CoInitialize()
         except Exception:
@@ -95,7 +120,7 @@ class MultisimClient:
         self._ensure_com()
         if self._app is None:
             try:
-                self._app = win32com.client.gencache.EnsureDispatch(PROG_ID)
+                self._app = win32_client.gencache.EnsureDispatch(PROG_ID)
             except Exception as exc:
                 raise RuntimeError(
                     "Could not activate the Multisim Automation API. Verify that "

--- a/mcp_server/multisim_mcp/server.py
+++ b/mcp_server/multisim_mcp/server.py
@@ -10,7 +10,6 @@ import shutil
 import uuid
 from pathlib import Path
 
-import pythoncom
 from mcp.server.fastmcp import FastMCP
 
 from multisim_mcp.multisim_client import (
@@ -941,7 +940,15 @@ def encode_ms14(source_xml: str, output_ms14: str | None = None) -> dict:
 
 
 def main() -> None:
-    pythoncom.CoInitialize()
+    if os.name == "nt":
+        try:
+            import pythoncom
+
+            pythoncom.CoInitialize()
+        except ImportError:
+            # Keep protocol introspection available so runtime_status can explain
+            # how to repair an incomplete Windows installation.
+            pass
     mcp.run()
 
 

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multisim-mcp"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Unofficial MCP server for NI Multisim Automation API"
 readme = "README.md"
 license = "MIT"
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.2.0,<2",
-    "pywin32>=306",
+    "pywin32>=306; sys_platform == 'win32'",
 ]
 
 [project.urls]

--- a/mcp_server/tests/test_unit.py
+++ b/mcp_server/tests/test_unit.py
@@ -1,6 +1,8 @@
 """COM-free unit tests for the Multisim MCP server."""
 
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,6 +13,7 @@ from multisim_mcp.multisim_client import (
     Ms14Codec,
     MultisimClient,
     clean_error,
+    require_compatible_runtime,
     runtime_diagnostics,
 )
 
@@ -52,6 +55,50 @@ class RuntimeDiagnosticsTest(unittest.TestCase):
         self.assertIn(result["python_bits"], (32, 64))
         self.assertEqual(result["required_python_bits"], 32)
         self.assertIn("python_executable", result)
+        self.assertIn("pywin32_available", result)
+        self.assertIn(result["runtime_mode"], ("automation", "introspection-only"))
+
+    def test_non_windows_runtime_supports_introspection_only(self) -> None:
+        with (
+            patch("multisim_mcp.multisim_client.os.name", "posix"),
+            patch("multisim_mcp.multisim_client.pythoncom", None),
+            patch("multisim_mcp.multisim_client.win32_client", None),
+        ):
+            result = runtime_diagnostics()
+            self.assertFalse(result["runtime_compatible"])
+            self.assertEqual(result["runtime_mode"], "introspection-only")
+            with self.assertRaisesRegex(RuntimeError, "requires Windows"):
+                require_compatible_runtime()
+
+    def test_server_imports_when_pywin32_is_unavailable(self) -> None:
+        script = """
+import builtins
+
+real_import = builtins.__import__
+
+def import_without_pywin32(name, *args, **kwargs):
+    if name == "pythoncom" or name.startswith("win32com"):
+        raise ImportError("blocked for portable introspection test")
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = import_without_pywin32
+from multisim_mcp.multisim_client import runtime_diagnostics
+from multisim_mcp import server
+
+result = runtime_diagnostics()
+assert result["pywin32_available"] is False
+assert result["runtime_mode"] == "introspection-only"
+assert server.mcp is not None
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
 
 
 class SpiceValueTest(unittest.TestCase):

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/yxy050208/multisim-mcp",
     "source": "github"
   },
-  "version": "0.1.0a1",
+  "version": "0.1.0a2",
   "websiteUrl": "https://github.com/yxy050208/multisim-mcp",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "multisim-mcp",
-      "version": "0.1.0a1",
+      "version": "0.1.0a2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tools/release_audit.py
+++ b/tools/release_audit.py
@@ -17,6 +17,7 @@ from pathlib import Path, PurePosixPath
 
 ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "mcp_server" / "pyproject.toml"
+PACKAGE_INIT = ROOT / "mcp_server" / "multisim_mcp" / "__init__.py"
 SERVER_JSON = ROOT / "server.json"
 MCP_NAME = "io.github.yxy050208/multisim-mcp"
 
@@ -72,9 +73,12 @@ def audit() -> list[Finding]:
         "CHANGELOG.md",
         "SECURITY.md",
         "THIRD_PARTY_NOTICES.md",
+        ".dockerignore",
+        "Dockerfile",
         "server.json",
         "docs/PUBLISHING.md",
         "docs/RELEASE_NOTES_v0.1.0-alpha.md",
+        "docs/RELEASE_NOTES_v0.1.0-alpha.2.md",
     )
     for relative in required:
         if not (ROOT / relative).is_file():
@@ -122,9 +126,19 @@ def audit() -> list[Finding]:
             r'(?m)^version\s*=\s*"([^"]+)"\s*$', pyproject_text
         )
         version = version_match.group(1) if version_match else None
-        if version != "0.1.0a1":
+        init_text = PACKAGE_INIT.read_text(encoding="utf-8")
+        init_version_match = re.search(
+            r'(?m)^__version__\s*=\s*"([^"]+)"\s*$', init_text
+        )
+        init_version = init_version_match.group(1) if init_version_match else None
+        if not version or version != init_version:
             findings.append(
-                Finding("error", "version", "pyproject 版本应为 0.1.0a1", str(PYPROJECT.relative_to(ROOT)))
+                Finding(
+                    "error",
+                    "version",
+                    "pyproject 与包 __version__ 必须存在且一致",
+                    str(PYPROJECT.relative_to(ROOT)),
+                )
             )
         repository_match = re.search(
             r'(?m)^Repository\s*=\s*"([^"]+)"\s*$', pyproject_text


### PR DESCRIPTION
## What changed

- adds a Linux/Docker `introspection-only` runtime that initializes the real MCP stdio server and exposes tool schemas;
- keeps all Multisim COM operations fail-closed outside 32-bit Windows with clear diagnostics;
- makes `pywin32` a Windows-only dependency;
- adds a minimal non-root validation image with an allowlisted Docker context;
- adds Ubuntu CI for container runtime diagnostics and MCP `tools/list`;
- prepares the `0.1.0a2` package and official Registry metadata.

## Why

Glama validates MCP servers in a Linux container by starting them and requesting introspection. Multisim itself is a licensed Windows desktop application exposed through COM, so the container must never claim to simulate circuits. This change separates protocol discovery from automation capability: registries can inspect the genuine server, while unsupported automation calls remain explicitly unavailable.

## User impact

Windows users retain the existing automation workflow. Registry users receive accurate platform diagnostics instead of an import failure. No NI software, samples, licenses, or extracted templates are included in the image or public package.

## Validation

- 50 COM-free tests pass locally.
- Wheel and sdist build successfully.
- Package metadata contains a Windows-only `pywin32` marker.
- Official `server.json` schema validation passes.
- Release audit passes apart from the expected dirty-tree warning before commit.
- Ubuntu container handshake validation runs in this PR's CI.
