### PR TITLE
feat: add DeepSeek Harness integration and npm release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
           assert result["introspection_ready"] is True
           '@ | python -
           multisim-mcp config --client generic --python $((Get-Command python).Source)
+      - name: Validate pinned DeepSeek Harness contract
+        run: |
+          python tools/check_deepseek_harness_compat.py --json
+          python tools/check_dsh_plugin_release.py --json
       - name: Compile installed sources
         run: python -m compileall mcp_server
       - name: Run COM-free tests against installed wheel
@@ -68,17 +72,26 @@ jobs:
           @'
           from importlib.resources import files
           from pathlib import Path
+          import json
           import tarfile
           import zipfile
           import multisim_mcp
 
           package = files("multisim_mcp")
           assert package.joinpath("templates/manifest.json").is_file()
+          harness_manifest = package.joinpath("harness_skills/manifest.json")
+          assert harness_manifest.is_file()
+          skill_names = json.loads(harness_manifest.read_text(encoding="utf-8"))["skills"]
+          assert len(skill_names) == 5
+          for name in skill_names:
+              assert package.joinpath(f"harness_skills/{name}/SKILL.md").is_file()
           wheels = list(Path("mcp_server/dist").glob("*.whl"))
           assert wheels
           with zipfile.ZipFile(wheels[0]) as archive:
               names = archive.namelist()
               assert any(name.endswith("licenses/LICENSE") for name in names)
+              assert any(name.endswith("harness_skills/manifest.json") for name in names)
+              assert sum(name.endswith("/SKILL.md") for name in names) == 5
               assert not any("/templates/" in name and name.endswith(".xml") for name in names)
               metadata_name = next(name for name in names if name.endswith(".dist-info/METADATA"))
               metadata = archive.read(metadata_name).decode("utf-8")
@@ -89,11 +102,13 @@ jobs:
               names = archive.getnames()
               assert any(name.endswith("/LICENSE") for name in names)
               assert any(name.endswith("/multisim_mcp/templates/manifest.json") for name in names)
+              assert any(name.endswith("/multisim_mcp/harness_skills/manifest.json") for name in names)
+              assert sum(name.endswith("/SKILL.md") for name in names) == 5
               assert not any("/templates/" in name and name.endswith(".xml") for name in names)
           print("Code-only wheel and sdist contain manifest/license and no extracted XML")
           '@ | python -
       - name: Compile release audit and local-pack tools
-        run: python -m compileall tools/release_audit.py tools/bootstrap_local_component_pack.py tools/extract_native_component_templates.py
+        run: python -m compileall tools/release_audit.py tools/check_deepseek_harness_compat.py tools/check_dsh_plugin_release.py tools/check_npm_pack_result.py tools/smoke_deepseek_harness.py tools/bootstrap_local_component_pack.py tools/extract_native_component_templates.py
 
   windows-x86-protocol:
     runs-on: windows-latest

--- a/.github/workflows/deepseek-harness-compatibility.yml
+++ b/.github/workflows/deepseek-harness-compatibility.yml
@@ -1,0 +1,120 @@
+name: DeepSeek Harness compatibility
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: deepseek-harness-compatibility
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  upstream-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+      - name: Check pinned and upstream contracts
+        run: |
+          python tools/check_deepseek_harness_compat.py \
+            --check-upstream \
+            --warn-only \
+            --json > deepseek-harness-compatibility.json
+      - name: Publish compatibility summary
+        env:
+          REPORT_PATH: deepseek-harness-compatibility.json
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(Path(os.environ["REPORT_PATH"]).read_text(encoding="utf-8"))
+          match = report["upstream_match"]
+          status = "matches the pinned contract" if match else "has changed; review required"
+          lines = [
+              "## DeepSeek Harness compatibility",
+              "",
+              f"Upstream {status}.",
+              f"Pinned version: `{report['pinned_harness_version']}`",
+              f"Errors: {report['errors']}; warnings: {report['warnings']}",
+          ]
+          for finding in report["findings"]:
+              lines.append(
+                  f"- **{finding['level']} / {finding['check']}**: {finding['message']}"
+              )
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines) + "\n")
+          PY
+
+  official-dsh-smoke:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    env:
+      NPM_CONFIG_AUDIT: "false"
+      NPM_CONFIG_FUND: "false"
+      NPM_CONFIG_UPDATE_NOTIFIER: "false"
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - name: Install Multisim MCP
+        run: python -m pip install ./mcp_server
+      - name: Run isolated official Harness smoke
+        shell: pwsh
+        run: |
+          python tools/smoke_deepseek_harness.py `
+            --install-timeout 300 `
+            --startup-timeout 120 `
+            --json > deepseek-harness-smoke.json
+          $smokeExit = $LASTEXITCODE
+          Get-Content deepseek-harness-smoke.json
+          exit $smokeExit
+      - name: Publish smoke summary
+        if: always()
+        shell: pwsh
+        run: |
+          if (-not (Test-Path deepseek-harness-smoke.json)) {
+            "## Official dsh smoke`n`nNo report was produced." >> $env:GITHUB_STEP_SUMMARY
+            exit 0
+          }
+          @'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(Path("deepseek-harness-smoke.json").read_text(encoding="utf-8-sig"))
+          status = "passed" if report["success"] else "failed"
+          lines = ["## Official dsh smoke", "", f"Smoke test **{status}**."]
+          if report["success"]:
+              lines.extend(
+                  [
+                      f"Pinned CLI: `{report['dsh_package']}@{report['dsh_version']}`",
+                      f"Config dump: `{report['config_dump']}`",
+                      f"Web ready: `{report['web_ready']}`",
+                      f"Elapsed: `{report['elapsed_seconds']} s`",
+                  ]
+              )
+          else:
+              lines.append(
+                  f"Error: `{report['error']['type']}` — {report['error']['message']}"
+              )
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines) + "\n")
+          '@ | python -

--- a/.github/workflows/publish-dsh-plugin.yml
+++ b/.github/workflows/publish-dsh-plugin.yml
@@ -1,0 +1,123 @@
+name: Verify or stage DeepSeek Harness plugin
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact plugin version from package.json
+        required: true
+        default: "1.0.0"
+        type: string
+      operation:
+        description: Verify only, or stage an update to an existing npm package
+        required: true
+        default: verify
+        type: choice
+        options:
+          - verify
+          - stage-existing
+      confirmation:
+        description: For staging, enter stage multisim-mcp-dsh-plugin@VERSION
+        required: false
+        type: string
+
+concurrency:
+  group: publish-dsh-plugin
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
+      RELEASE_OPERATION: ${{ inputs.operation }}
+      RELEASE_CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Use release npm CLI
+        run: npm install --global npm@12.0.2 --ignore-scripts
+      - name: Validate explicit staging confirmation
+        shell: bash
+        run: |
+          if [[ "$RELEASE_OPERATION" == "stage-existing" ]]; then
+            expected="stage multisim-mcp-dsh-plugin@$RELEASE_VERSION"
+            if [[ "$RELEASE_CONFIRMATION" != "$expected" ]]; then
+              echo "Staging confirmation must equal: $expected" >&2
+              exit 1
+            fi
+          fi
+      - name: Validate release and registry state
+        run: >-
+          python tools/check_dsh_plugin_release.py
+          --expected-version "$RELEASE_VERSION"
+          --check-registry
+          --json
+      - name: Inspect npm package boundary
+        shell: bash
+        run: |
+          npm pack ./integrations/deepseek-harness \
+            --dry-run --json --ignore-scripts > npm-pack.json
+          python tools/check_npm_pack_result.py npm-pack.json \
+            --expected-version "$RELEASE_VERSION"
+
+  stage:
+    if: ${{ inputs.operation == 'stage-existing' }}
+    needs: verify
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/multisim-mcp-dsh-plugin
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Use release npm CLI
+        run: npm install --global npm@12.0.2 --ignore-scripts
+      - name: Require the existing owned package and a new version
+        run: >-
+          python tools/check_dsh_plugin_release.py
+          --expected-version "$RELEASE_VERSION"
+          --check-registry
+          --require-existing-package
+          --json
+      - name: Pack the exact staged artifact
+        id: pack
+        shell: bash
+        run: |
+          npm pack ./integrations/deepseek-harness \
+            --json --ignore-scripts > npm-pack.json
+          python tools/check_npm_pack_result.py npm-pack.json \
+            --expected-version "$RELEASE_VERSION"
+          tarball=$(python tools/check_npm_pack_result.py npm-pack.json \
+            --expected-version "$RELEASE_VERSION" --filename-only)
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+          sha256sum "$tarball"
+      - name: Stage package with npm Trusted Publishing
+        run: npm stage publish "${{ steps.pack.outputs.tarball }}" --access public

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
+      - name: Validate pinned DeepSeek Harness contract
+        run: python tools/check_deepseek_harness_compat.py --json
       - name: Build distributions
         run: |
           python -m pip install --upgrade pip build
@@ -40,11 +42,15 @@ jobs:
           with zipfile.ZipFile(wheel) as archive:
               names = archive.namelist()
               assert not any("/templates/" in name and name.endswith(".xml") for name in names)
+              assert any(name.endswith("harness_skills/manifest.json") for name in names)
+              assert sum(name.endswith("/SKILL.md") for name in names) == 5
               metadata_name = next(name for name in names if name.endswith(".dist-info/METADATA"))
               assert marker in archive.read(metadata_name).decode("utf-8")
           with tarfile.open(sdist, "r:gz") as archive:
               names = archive.getnames()
               assert not any("/templates/" in name and name.endswith(".xml") for name in names)
+              assert any(name.endswith("/multisim_mcp/harness_skills/manifest.json") for name in names)
+              assert sum(name.endswith("/SKILL.md") for name in names) == 5
               readme = next(member for member in archive.getmembers() if member.name.endswith("/README.md"))
               assert marker in archive.extractfile(readme).read().decode("utf-8")
           PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,40 @@
 
 ## [Unreleased]
 
-暂无变更。 / No changes yet.
+### 中文
+
+- 新增 2.0 综合路线图，确定先平台化、再纠错优化、开放仿真后端、可视化工作台和
+  KiCad 工程输出的开发顺序。
+- 新增 DeepSeek 与官方 DeepSeek Harness 兼容说明，包括凭据边界、工具规模、
+  Resources/Prompts 当前限制和版本验证矩阵。
+- 配置生成器新增 `deepseek-harness` 客户端，输出官方 MCP Client 使用的 Cordis
+  插件片段，并校验上游 `serverName` 约束。
+- 新增四种服务端 Tool Profile；默认 `full` 保持完整工具兼容，其他档案可减少
+  DeepSeek Harness 等客户端的工具 schema 上下文占用。
+- 新增列出、分页读取、受控导出和汇总实验产物的四个 Tool 等价入口，供暂不消费
+  MCP Resources 的客户端使用；导出限定在显式批准的根目录内。
+- 新增五个版本化 DeepSeek Harness Skill，覆盖创建、纠错、比较、报告和指标验证；
+  `harness-skills` 命令可安全安装到项目 `.dsh/skills`，默认拒绝覆盖。
+- 新增机器可读 Harness 兼容清单、确定性本地门禁和每周非阻塞上游版本漂移监控。
+- 新增可独立安装的 `multisim-mcp-dsh-plugin` bundle 源码，以及隔离、无 API Key、
+  固定官方 dsh 版本的配置组合与真实启动烟雾测试。
+
+### English
+
+- Added the post-1.0 platform, optimization, multi-EDA, and visual-workbench roadmap.
+- Documented the DeepSeek and official DeepSeek Harness compatibility baseline.
+- Added a `deepseek-harness` client target that renders a validated Cordis MCP
+  plugin fragment without forwarding model credentials to the MCP process.
+- Added four server-side tool profiles while preserving the complete `full`
+  profile as the default.
+- Added four Tool equivalents for listing, paginating, exporting, and summarizing
+  experiment artifacts when a client does not consume MCP Resources.
+- Added five versioned DeepSeek Harness skills plus a safe, no-clobber project
+  installer for `.dsh/skills`.
+- Added a machine-readable Harness compatibility manifest, deterministic local
+  gate, and weekly non-blocking upstream drift monitor.
+- Added an installable `multisim-mcp-dsh-plugin` source bundle and an isolated,
+  credential-free smoke test against the pinned official dsh CLI.
 
 ## [1.0.0] - 2026-08-10
 

--- a/README.en.md
+++ b/README.en.md
@@ -166,11 +166,36 @@ C:\path\to\python32\Scripts\multisim-mcp.exe config `
   --client codex `
   --python C:\path\to\python32\python.exe `
   --template-dir C:\MultisimMcp\component-pack
+
+# Print a DeepSeek Harness Cordis plugin fragment.
+C:\path\to\python32\Scripts\multisim-mcp.exe config `
+  --client deepseek-harness `
+  --python C:\path\to\python32\python.exe `
+  --template-dir C:\MultisimMcp\component-pack `
+  --work-dir C:\msre_exp `
+  --artifact-export-dir C:\MultisimMcp\exports `
+  --tool-profile experiment
+
+# Install the five bilingual experiment skills from a Harness project root.
+C:\path\to\python32\Scripts\multisim-mcp.exe harness-skills --output .dsh/skills
 ```
 
 The generator prints a copy-pasteable fragment by default. `--output` writes a
 new file and refuses to replace one unless `--force` is also present. It never
-merges into a live Claude Desktop or Codex configuration automatically.
+merges into a live Claude Desktop, Codex, or Harness configuration automatically.
+See the [DeepSeek / Harness integration guide](docs/DEEPSEEK_HARNESS.md) for the
+credential boundary and compatibility baseline.
+`--tool-profile core|experiment|optimization|full` limits tool discovery;
+omitting it preserves the 55-tool `full` compatibility mode. Artifact export is
+disabled unless `--artifact-export-dir` explicitly approves a destination root.
+The Harness skill installer preserves existing files unless `--force` is explicit.
+Repository maintainers can validate the pinned local Harness contract with
+`python tools/check_deepseek_harness_compat.py --json`.
+An independently installable source bundle is available under
+[`integrations/deepseek-harness`](integrations/deepseek-harness); it has not yet
+been published to npm. Maintainers should follow the
+[npm release guide](docs/DEEPSEEK_HARNESS_NPM_RELEASE.md) for the first 2FA
+publication and later OIDC-staged updates.
 
 Manual MCP client configuration:
 
@@ -199,6 +224,8 @@ See [SECURITY.md](SECURITY.md).
 Alpha users should read the [1.0 migration guide](docs/MIGRATION_TO_1.0.md).
 Durable-job and artifact recovery procedures are documented in
 [the recovery guide](docs/RECOVERY.md).
+The diagnosis, optimization, multi-EDA, and visual-workbench direction is
+documented in the [2.0 roadmap](docs/ROADMAP_TO_2.0.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -183,10 +183,34 @@ C:\path\to\python32\Scripts\multisim-mcp.exe config `
   --client codex `
   --python C:\path\to\python32\python.exe `
   --template-dir C:\MultisimMcp\component-pack
+
+# 输出 DeepSeek Harness Cordis 插件片段
+C:\path\to\python32\Scripts\multisim-mcp.exe config `
+  --client deepseek-harness `
+  --python C:\path\to\python32\python.exe `
+  --template-dir C:\MultisimMcp\component-pack `
+  --work-dir C:\msre_exp `
+  --artifact-export-dir C:\MultisimMcp\exports `
+  --tool-profile experiment
+
+# 在 Harness 项目根安装五个双语实验 Skill
+C:\path\to\python32\Scripts\multisim-mcp.exe harness-skills --output .dsh/skills
 ```
 
 配置生成器默认只打印可复制片段；`--output` 写入新文件，除非再传入 `--force`，
-否则不会覆盖已有文件。它不会自动合并 Claude Desktop 或 Codex 的现有配置。
+否则不会覆盖已有文件。它不会自动合并 Claude Desktop、Codex 或 Harness 的现有配置。
+DeepSeek 模型与官方 Harness 的分层、凭据边界和版本兼容性见
+[`DeepSeek / Harness 适配说明`](docs/DEEPSEEK_HARNESS.md)。
+`--tool-profile core|experiment|optimization|full` 可限制客户端发现的工具；
+省略时保持 55 个工具全部可用的 `full` 兼容模式。产物导出只有在设置
+`--artifact-export-dir` 后可用，并且只能写入该目录之下。
+Harness Skill 安装默认不覆盖现有文件；需要恢复打包版本时显式增加 `--force`。
+仓库维护者可用 `python tools/check_deepseek_harness_compat.py --json` 验证固定的
+Harness 本地契约；版本与上游检查细节见适配说明。
+需要把集成作为 Harness 插件安装时，可使用
+[`integrations/deepseek-harness`](integrations/deepseek-harness) 中的独立 bundle；
+它目前支持本地源码安装，尚未发布到 npm。维护者的首次 2FA 发布与后续 OIDC
+暂存流程见 [`npm 发布手册`](docs/DEEPSEEK_HARNESS_NPM_RELEASE.md)。
 
 手工 MCP 客户端配置：
 
@@ -205,6 +229,8 @@ C:\path\to\python32\Scripts\multisim-mcp.exe config `
 元件覆盖和剩余边界见 [`docs/COMPONENT_COVERAGE.md`](docs/COMPONENT_COVERAGE.md)。
 从 alpha 升级请阅读 [`docs/MIGRATION_TO_1.0.md`](docs/MIGRATION_TO_1.0.md)；任务与
 实验恢复流程见 [`docs/RECOVERY.md`](docs/RECOVERY.md)。
+1.0 之后的纠错、优化、多 EDA 后端和可视化工作台计划见
+[`2.0 综合路线图`](docs/ROADMAP_TO_2.0.md)。
 
 ## 仓库结构
 

--- a/compatibility/deepseek-harness.json
+++ b/compatibility/deepseek-harness.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "verified_date": "2026-08-18",
+  "status": "developer-preview",
+  "upstream": {
+    "repository": "https://github.com/deepseek-ai/deepseek-harness",
+    "root_package_url": "https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/master/package.json",
+    "dsh_cli_package_url": "https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/master/apps/cli/package.json",
+    "mcp_client_package_url": "https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/master/packages/mcp/mcp-client/package.json",
+    "harness_version": "0.1.0-rc.7",
+    "dsh_cli_package": "@deepseek-ai/dsh",
+    "dsh_cli_version": "0.1.0-rc.7",
+    "mcp_client_package": "@deepseek-ai/dsh-mcp-client",
+    "mcp_client_version": "0.1.0-rc.7",
+    "node_engine": "^22.19.0 || >=24.0.0",
+    "package_manager": "pnpm@11.7.0",
+    "mcp_sdk_range": "^1.12.0"
+  },
+  "contract": {
+    "transport": "stdio",
+    "tool_name_prefix": "mcp__multisim__",
+    "server_name_pattern": "^[A-Za-z0-9_-]{1,32}$",
+    "mcp_resources_bridged": false,
+    "mcp_prompts_bridged": false,
+    "skill_discovery_root": ".dsh/skills",
+    "bundle_package": "multisim-mcp-dsh-plugin",
+    "bundle_version": "1.0.0",
+    "bundle_path": "integrations/deepseek-harness",
+    "tool_profiles": {
+      "core": 26,
+      "experiment": 39,
+      "optimization": 40,
+      "full": 55
+    },
+    "skills": [
+      "multisim-create-experiment",
+      "multisim-debug-circuit",
+      "multisim-compare-experiments",
+      "multisim-write-lab-report",
+      "multisim-verify-requirements"
+    ]
+  }
+}

--- a/docs/DEEPSEEK_HARNESS.md
+++ b/docs/DEEPSEEK_HARNESS.md
@@ -1,0 +1,256 @@
+# DeepSeek 与 DeepSeek Harness 适配
+
+本文说明 Multisim MCP 如何接入 DeepSeek 模型和 DeepSeek 官方 Harness，
+并记录当前兼容边界。DeepSeek API 和 DeepSeek Harness 是两层不同能力：
+
+- DeepSeek API 提供模型、推理和函数工具调用；
+- DeepSeek Harness (`dsh`) 提供代理循环、工具、会话、审批和 Web UI；
+- Multisim MCP 继续作为本地工程工具服务器，不保存模型 API Key。
+
+## 当前兼容基线
+
+本说明核对日期为 2026-08-18。DeepSeek Harness 官方仓库仍标记为
+Developer Preview，并明确提示可能发生破坏性兼容变更。当前公开的
+`@deepseek-ai/dsh-mcp-client` 包版本为 `0.1.0-rc.7`。
+
+已确认的 MCP Client 行为：
+
+- 支持 `stdio` 和 `streamable-http`；
+- 外部工具注册为 `mcp__<serverName>__<rawName>`；
+- 支持工具列表变化、断线重连、超时和完整世代替换；
+- 当前只桥接 MCP Tools；Resources 和 Prompts 尚无 Harness 消费接口；
+- 工具结果保留结构化内容，但较大的二进制产物不应直接进入模型上下文。
+
+因此目前可直接使用 Multisim MCP 的工具层；实验 Resource 已有 Tool 等价入口，
+五个 MCP Prompt 也已经通过 Harness Skill Bundle 提供等价工作流。
+
+上游资料：
+
+- <https://github.com/deepseek-ai/deepseek-harness>
+- <https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/mcp/mcp-client/README.zh.md>
+- <https://github.com/deepseek-ai/deepseek-harness/blob/master/apps/cli/README.zh.md>
+- <https://github.com/deepseek-ai/deepseek-harness/blob/master/apps/cli/reference/README.zh.md>
+- <https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/skills.zh.md>
+- <https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/workflow.zh.md>
+- <https://api-docs.deepseek.com/api/create-chat-completion/>
+
+## 生成 Harness 配置片段
+
+使用安装了 `multisim-mcp` 的 32 位 Python 运行：
+
+```powershell
+C:\path\to\python32\Scripts\multisim-mcp.exe config `
+  --client deepseek-harness `
+  --python C:\path\to\python32\python.exe `
+  --template-dir C:\MultisimMcp\component-pack `
+  --work-dir C:\msre_exp `
+  --artifact-export-dir C:\MultisimMcp\exports `
+  --tool-profile experiment
+```
+
+命令输出一个 Cordis 插件配置片段，不会修改 Harness 的现有 profile，
+也不会读取或输出 `DEEPSEEK_API_KEY`。把片段加入所选 profile 的 Cordis
+配置层后，可用以下命令检查最终组合：
+
+```powershell
+dsh --profile web --dump-config
+```
+
+片段形状：
+
+```yaml
+- id: "mcp-multisim"
+  name: "@deepseek-ai/dsh-mcp-client"
+  config:
+    serverName: "multisim"
+    transport: "stdio"
+    command: "C:\\path\\to\\python32\\python.exe"
+    args:
+      - "-m"
+      - "multisim_mcp.server"
+    env:
+      MULTISIM_MCP_ARTIFACT_EXPORT_DIR: "C:\\MultisimMcp\\exports"
+      MULTISIM_MCP_TEMPLATE_DIR: "C:\\MultisimMcp\\component-pack"
+      MULTISIM_MCP_TOOL_PROFILE: "experiment"
+      MULTISIM_MCP_WORKDIR: "C:\\msre_exp"
+    failOnStartupError: true
+    toolCallTimeoutMs: 120000
+    reconnect:
+      enabled: true
+      initialDelayMs: 500
+      maxDelayMs: 30000
+      maxAttempts: 10
+```
+
+Harness 的 `serverName` 当前只接受 1--32 个字母、数字、下划线或连字符；
+配置生成器会单独执行这个限制，不会生成上游无法加载的名称。
+
+## DeepSeek API Key 边界
+
+正确的凭据流向：
+
+```text
+DEEPSEEK_API_KEY -> DeepSeek Harness -> DeepSeek API
+Multisim license -> local Multisim installation -> 32-bit worker
+```
+
+不要把 `DEEPSEEK_API_KEY` 放入 Multisim MCP 的 `env`、实验 manifest、报告
+或诊断输出。Multisim MCP 不需要也不应该直接调用模型 API。
+
+## 模型与工具规模
+
+DeepSeek Chat Completions 当前允许最多 128 个函数工具，函数名最长 64 个
+字符。Multisim MCP 1.0 的 51 个工具可以被加载，但完整 schema 会占用模型
+上下文，也会降低工具选择稳定性。当前已经提供以下服务端 Tool Profile：
+
+| Profile | 工具数 | 用途 |
+| --- | ---: | --- |
+| `core` | 26 | 诊断、连接、电路检查、文件和基础仿真 |
+| `experiment` | 39 | 电路生成、实验任务、测量、验证、报告和产物访问 |
+| `optimization` | 40 | 参数调整、基础仿真、指标验证、实验扫描和产物访问 |
+| `full` | 55 | 完整兼容模式，也是默认值 |
+
+通过配置生成器的 `--tool-profile` 设置，或手工设置
+`MULTISIM_MCP_TOOL_PROFILE`。Profile 在服务端生成稳定的 `tools/list`；没有被
+选择的工具不会注册到该进程，但原有 Python 内部调用保持不变。`runtime_status`
+会返回当前 profile、工具数和可选 profile。
+
+Tool Profile 是上下文与工作流优化机制，不是安全权限系统。任意命令、路径边界、
+输出目录和危险功能仍由现有安全策略独立控制。
+
+## Resources 和 Prompts 的兼容
+
+Harness 当前不消费 MCP Resources 和 Prompts。现已提供四个 Tool 等价入口：
+
+- `list_experiment_artifacts`：列出名称、URI、MIME、大小和 SHA-256；
+- `read_experiment_artifact`：只读取有界文本或分页内容；
+- `export_experiment_artifact`：把二进制产物复制到用户批准的位置；
+- `get_experiment_summary`：汇总测量、验证和报告入口；
+
+其中 `read_experiment_artifact` 只接受固定文本产物，并以字符偏移分页；二进制
+产物不会以内联 base64 返回。`export_experiment_artifact` 只允许复制固定产物到
+`MULTISIM_MCP_ARTIFACT_EXPORT_DIR` 下的相对子目录，默认拒绝覆盖。该目录必须由
+用户或客户端配置明确批准。
+
+## 安装 Harness Skill Bundle
+
+在 Harness 项目根目录运行：
+
+```powershell
+multisim-mcp harness-skills --output .dsh/skills
+```
+
+安装器会写入五个随 Python 包版本化发布的项目级 Skill：
+
+- `/multisim-create-experiment`：根据需求创建并运行实验；
+- `/multisim-debug-circuit`：诊断电路、证据和失败原因；
+- `/multisim-compare-experiments`：比较两个实验及其产物；
+- `/multisim-write-lab-report`：基于已记录证据编写实验报告；
+- `/multisim-verify-requirements`：逐条验证工程指标。
+
+Harness 会从项目的 `.dsh/skills` 自动发现这些 Skill。用户可以用上述斜杠名称
+显式调用，模型也可以根据 Skill 描述自行加载。MCP 工具在 Harness 中通常显示为
+`mcp__multisim__<tool-name>`；Skill 正文使用原始工具名描述步骤，避免把
+`serverName` 硬编码进工作流。
+
+安装器默认拒绝覆盖已有 `SKILL.md`。只有明确希望恢复打包版本时才使用
+`--force`；自动化环境可增加 `--json` 获得稳定的安装结果。之所以采用 Skill
+而不是动态 Workflow，是因为这五项能力是固定、可审查的实验说明。Harness 的
+Workflow seam 更适合由模型生成编排脚本和子代理的动态任务，后续复杂优化流程
+确有这种需求时再单独引入。
+
+## 独立 Harness Bundle
+
+仓库同时提供可独立安装的 bundle 源码：
+[`integrations/deepseek-harness`](../integrations/deepseek-harness)。它按照官方
+`dsh.bundle.patch` 约定声明 `cordis.patch.yml`，并把 MCP Client 依赖固定为
+`0.1.0-rc.7`。
+
+```powershell
+$env:MULTISIM_MCP_PYTHON = "C:\path\to\python32\python.exe"
+dsh plugin --profile web add .\integrations\deepseek-harness
+dsh --profile web --dump-config
+```
+
+当前 bundle 可以从源码路径安装，但尚未发布到 npm。正式 npm 发布需要单独验证
+包名所有权、Trusted Publishing 和固定 Harness 版本，不能与 Python 包发布隐式
+绑定。配置只转发 `MULTISIM_MCP_*` 和 Python 运行选项，不会把
+`DEEPSEEK_API_KEY` 传入 MCP 子进程。
+首次发布、Registry 防抢注检查和后续 OIDC 暂存审批流程见
+[`DeepSeek Harness 插件 npm 发布手册`](DEEPSEEK_HARNESS_NPM_RELEASE.md)。
+
+## 官方 dsh 端到端烟雾测试
+
+维护者可以运行：
+
+```powershell
+python tools/smoke_deepseek_harness.py --json
+```
+
+该脚本使用临时 `DSH_HOME`，删除子进程环境中的 `DEEPSEEK_API_KEY`，强制关闭
+Harness 遥测，并固定运行 `@deepseek-ai/dsh@0.1.0-rc.7`。它先验证配置组合，再
+启动 Web profile；由于 MCP 配置启用了 `failOnStartupError`，只有官方 MCP Client
+成功连接、完成初始工具同步并且 Web 服务就绪才算通过。脚本不执行模型请求，也不
+需要 DeepSeek API Key。
+
+真实启动测试只在每周或手动 GitHub Workflow 中运行，避免 npm 首次下载时间和
+上游注册表波动拖慢普通 PR。它与非阻塞的版本漂移检查不同：固定版真实启动失败会
+让烟雾测试 job 失败，作为需要处理的兼容信号。
+
+PDF、图片、raw 和 `.ms14` 默认只返回元数据与本地引用，不应把完整 base64
+塞入模型历史。所有路径继续经过实验注册表和工作区边界检查。
+
+## 验证矩阵
+
+每个已支持的 Harness 基线应验证：
+
+1. stdio initialize 和分页 `tools/list`；
+2. `runtime_status` 和一个无 COM 工具调用；
+3. Windows 32 位环境中的持久实验提交与状态查询；
+4. 工具名不超过 DeepSeek 函数命名限制；
+5. 工具参数 schema 能被 Harness 接受；
+6. 子进程崩溃后的重连不会重复注册工具；
+7. stdout 没有日志、编码或 pywin32 诊断污染；
+8. 配置和产物中不存在 DeepSeek API Key。
+
+固定版本测试负责发布门禁；跟踪 Harness 最新版本的定时任务只报告兼容
+状态，不应在上游发生破坏性变更时阻塞 Multisim MCP 的普通提交。
+
+## 版本门禁与上游监控
+
+仓库使用 [`compatibility/deepseek-harness.json`](../compatibility/deepseek-harness.json)
+记录已验证基线。当前固定值包括 Harness 与 MCP Client `0.1.0-rc.7`、Node
+`^22.19.0 || >=24.0.0`、pnpm `11.7.0` 和上游 MCP SDK `^1.12.0`。
+
+维护者可以执行确定性的本地契约检查；该命令不访问网络：
+
+```powershell
+python tools/check_deepseek_harness_compat.py --json
+```
+
+准备发布或调整固定版本时，执行严格上游检查：
+
+```powershell
+python tools/check_deepseek_harness_compat.py --check-upstream --json
+```
+
+每周 GitHub Actions 使用 `--warn-only` 比较官方仓库。版本、Node 范围、包管理器、
+MCP Client 名称或 MCP SDK 范围发生变化时，它会写入 Job Summary，但不阻塞普通
+开发。出现漂移不等于已经不兼容；维护者需要先运行 stdio、工具 schema、Skill
+发现和 Windows 32 位实验矩阵，再更新固定值与核对日期。
+
+## 独立平台中的 DeepSeek
+
+未来可视化工作台需要内置模型时，应通过通用 `ModelProvider` 接口接入
+DeepSeek。该接口负责消息、工具循环、用量和取消，不负责电路或仿真逻辑。
+同一 EDA Core 必须可以由 DeepSeek、其他模型或完全无模型的确定性脚本调用。
+
+## English summary
+
+DeepSeek is a model provider; DeepSeek Harness is an agent runtime. The initial
+integration generates a version-gated Cordis MCP client fragment and keeps all
+model credentials outside Multisim MCP. The current Harness bridge consumes MCP
+tools but not resources or prompts. Bounded artifact tools, tool profiles, and a
+five-skill project bundle now provide equivalent access. Pinned compatibility
+checks now cover the local contract, while real Windows Harness
+execution remains part of the release matrix.

--- a/docs/DEEPSEEK_HARNESS_NPM_RELEASE.md
+++ b/docs/DEEPSEEK_HARNESS_NPM_RELEASE.md
@@ -1,0 +1,87 @@
+# DeepSeek Harness 插件 npm 发布手册
+
+本文只适用于 `integrations/deepseek-harness` 中的独立 npm bundle。Python
+包、MCP Registry 和该 bundle 是三个独立发布物；版本当前保持同步，但不能由同一个
+上传步骤隐式联动。
+
+## 安全边界
+
+- 包名固定为 `multisim-mcp-dsh-plugin`，发布前必须再次查询 Registry；
+- npm 包只能包含 `package.json`、`README.md`、`LICENSE` 和
+  `cordis.patch.yml`；
+- 仓库工作流不保存 `NPM_TOKEN`，后续版本使用 GitHub OIDC；
+- npm 的 `DEEPSEEK_API_KEY`、Multisim 文件、实验产物和本地绝对路径都不得进入包；
+- GitHub `npm` Environment 应配置 required reviewer，防止误触发上传。
+
+本地预检：
+
+```powershell
+python tools/check_dsh_plugin_release.py `
+  --expected-version 1.0.0 `
+  --check-registry `
+  --json
+npm pack .\integrations\deepseek-harness --dry-run --json --ignore-scripts
+```
+
+发布守卫把 Registry 的 404 解释为“当前未被占用”，但这不是名称保留。首次发布前
+必须重新执行；如果 Registry 已出现同名包且其 repository 不是本项目，守卫会失败。
+
+## 首次发布 1.0.0
+
+npm 的 staged publishing 明确要求包已经存在，因此全新包不能使用
+`npm stage publish`。首次发布需要包所有者在可信本机完成，并使用账户 2FA：
+
+```powershell
+cd integrations\deepseek-harness
+npm login
+npm pack --json --ignore-scripts
+npm publish .\multisim-mcp-dsh-plugin-1.0.0.tgz --access public
+```
+
+不要把一次性验证码写入脚本、文档或 shell 历史；让 npm 在交互提示中请求 2FA。
+发布前应人工查看 `npm pack --dry-run --json` 的文件列表和 tarball SHA-256。发布后
+立即核对：
+
+```powershell
+npm view multisim-mcp-dsh-plugin@1.0.0 `
+  name version repository dist.integrity dist.shasum --json
+```
+
+## 首次发布后的 Trusted Publishing
+
+在 npmjs.com 的该包 Settings → Trusted Publisher 中配置：
+
+| 字段 | 值 |
+| --- | --- |
+| Provider | GitHub Actions |
+| Organization or user | `yxy050208` |
+| Repository | `multisim-mcp` |
+| Workflow filename | `publish-dsh-plugin.yml` |
+| Environment | `npm` |
+| Allowed actions | 只允许 `npm stage publish` |
+
+然后把 package publishing access 设置为“Require two-factor authentication and
+disallow tokens”，并撤销不再需要的自动化 Token。每个 npm 包只能配置一个 Trusted
+Publisher；工作流文件名和 Environment 名必须完全一致。
+
+## 后续版本
+
+1. 同步 Python 包、兼容性清单与 bundle 的版本，并通过 CI。
+2. 手动运行 GitHub Actions 的 `Verify or stage DeepSeek Harness plugin`。
+3. 输入目标版本，选择 `stage-existing`，确认文本填写
+   `stage multisim-mcp-dsh-plugin@<version>`。
+4. `npm` Environment reviewer 批准后，工作流使用短期 OIDC 凭据上传暂存包。
+5. 在 npmjs.com 的 Staged Packages 页面下载并复核 tarball，再以账户 2FA 批准。
+6. 用 `npm view` 核对版本、repository、integrity 和 provenance。
+
+默认的 `verify` 操作只验证版本、Registry 归属和打包边界，不请求 OIDC，也不会上传。
+暂存工作流会拒绝尚不存在的包、已经发布的版本以及 repository 不属于本项目的同名包。
+
+## English summary
+
+The first publication must be performed interactively with maintainer 2FA,
+because npm does not allow staged publishing for a brand-new package. After the
+package exists, configure `publish-dsh-plugin.yml` as a stage-only trusted
+publisher bound to the `npm` GitHub Environment. Future CI runs use short-lived
+OIDC credentials to stage, while a maintainer still reviews and approves every
+release with 2FA. No long-lived npm publish token is stored in the repository.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -91,3 +91,17 @@ English: tag only after a final staged-file audit; never attach the local templa
 
 English: publish in order—green CI, tag/PyPI, verified GitHub Release, MCP
 Registry, then community-directory metadata.
+
+## 7. DeepSeek Harness npm bundle
+
+`integrations/deepseek-harness` 是独立 npm 发布物。首次发布不能使用 npm staged
+publishing，必须由维护者本地登录并通过 2FA 发布。包存在后，在 npm 中把
+`publish-dsh-plugin.yml` 配置为绑定 GitHub `npm` Environment、且只允许
+`npm stage publish` 的 Trusted Publisher；后续版本先由 OIDC 暂存，再由维护者以
+2FA 审批。仓库不保存长期 npm 发布 Token。
+
+完整预检、首次发布和后续审批步骤见
+[`DEEPSEEK_HARNESS_NPM_RELEASE.md`](DEEPSEEK_HARNESS_NPM_RELEASE.md)。
+
+English: the first npm publication is interactive with 2FA. Later releases use
+stage-only OIDC and require a separate maintainer review and 2FA approval.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -78,3 +78,16 @@ adding an ignore rule does not remove a file that is already staged.
 - [x] Push annotated tag `v1.0.0` and verify the Trusted Publishing result on PyPI.
 - [x] Publish matching MCP Registry metadata and GitHub Release artifacts.
 - [x] Verify Glama and awesome-mcp-servers directory metadata after publication.
+
+## DeepSeek Harness npm bundle 1.0.0
+
+- [x] Pin the official Harness CLI and MCP client compatibility baseline.
+- [x] Restrict the npm tarball to four reviewed files.
+- [x] Add a Registry ownership/version guard with unit tests.
+- [x] Add verify-only and stage-existing GitHub Actions paths.
+- [ ] Re-run the Registry guard immediately before the first publication.
+- [ ] Publish `multisim-mcp-dsh-plugin@1.0.0` interactively with maintainer 2FA.
+- [ ] Configure `publish-dsh-plugin.yml` as a stage-only npm Trusted Publisher.
+- [ ] Protect the GitHub `npm` Environment with required reviewers.
+- [ ] Disallow traditional publish tokens and verify package provenance on the
+      next staged release.

--- a/docs/ROADMAP_TO_2.0.md
+++ b/docs/ROADMAP_TO_2.0.md
@@ -1,0 +1,150 @@
+# Multisim MCP 2.0 综合开发路线
+
+本文定义 `v1.0.0` 之后的开发顺序。核心目标不是继续增加彼此独立的
+MCP 工具，而是把已经验证的 Multisim 实验能力发展为可诊断、可纠错、
+可优化并可接入多个 EDA 后端的工程内核。
+
+## 产品决策
+
+- MCP 在 2.0 之前继续作为主要交付接口。
+- 从 1.1 开始，领域模型、任务、优化和报告不得依赖 MCP 上下文。
+- Multisim 作为第一个 `EdaBackend`，不再充当通用数据模型。
+- 纠错与参数优化优先于大规模 EDA 扩展和完整 GUI。
+- 可视化工作台先做只读工程审查，再增加修改审批和运行控制。
+- DeepSeek、Codex、Claude 等模型都是入口，不进入仿真核心。
+
+## 目标架构
+
+```text
+AI client / Visual Workbench
+            |
+   MCP adapter / Local API
+            |
+     Application service
+            |
+  EDA Core + Optimization Core
+      |         |          |
+ Multisim    ngspice     KiCad
+```
+
+建议的稳定对象：
+
+- `CircuitDesign`：元件、网络、参数、模型引用和设计注释；
+- `DesignRequirements`：指标、容差、优先级和硬约束；
+- `SimulationPlan`：工作点、DC、AC、瞬态和批量分析；
+- `DesignPatch`：带理由、前值、后值和回滚信息的最小修改；
+- `SimulationResult`：波形、测量、诊断和后端元数据；
+- `OptimizationRun`：候选、目标函数、约束、停止原因和最优解；
+- `ArtifactSet`：原理图、网表、BOM、数据、日志和报告清单。
+
+所有持久化对象都必须有 `schema_version`，且升级过程可测试、可回滚。
+
+## 阶段 A：1.1 平台化基础
+
+目标是在不破坏 1.0 MCP 接口的前提下建立可复用内核。
+
+- [ ] 定义 `EdaBackend` 能力接口和能力发现结果。
+- [ ] 定义第一版 `CircuitDesign`、`DesignPatch` 和 `ArtifactSet`。
+- [ ] 把实验执行从 MCP 工具函数迁移到应用服务。
+- [ ] 将 Multisim COM 操作保留在独立 32 位 worker 中。
+- [ ] 为项目目录、实验目录和优化目录增加版本化 manifest。
+- [ ] 保持现有 51 个工具、19 个 Resource 模板和 5 个 Prompt 兼容。
+- [x] 规划 DeepSeek 与 DeepSeek Harness 的分层适配。
+- [x] 增加 DeepSeek Harness 客户端配置生成器。
+- [x] 增加 `core`、`experiment`、`optimization` 和 `full` Tool Profile。
+- [x] 为不消费 MCP Resources 的客户端增加有界产物 Tool 等价入口。
+- [x] 为不消费 MCP Prompts 的 Harness 客户端增加五个项目级 Skill。
+- [x] 增加固定版本兼容清单、本地契约门禁和非阻塞上游漂移监控。
+- [x] 增加可独立安装的 Harness bundle 源码和固定版真实启动烟雾测试。
+
+阶段门禁：现有 1.0 回归全部通过，MCP 适配器与核心服务之间不共享
+传输层对象，Multisim 后端可由无 COM 的假后端替换测试。
+
+## 阶段 B：1.2 诊断、纠错与参数优化
+
+第一版只允许有界参数修改，不进行任意拓扑重写。
+
+- [ ] `diagnose_design`：结构、偏置、饱和、收敛和指标失败诊断；
+- [ ] `propose_design_changes`：生成结构化、可审查的 `DesignPatch`；
+- [ ] `apply_design_patch` / `revert_design_patch`：事务化修改和回滚；
+- [ ] `optimize_design`：目标、硬约束、范围和最大实验预算；
+- [ ] `compare_design_variants`：基线、候选和误差证据比较；
+- [ ] E12/E24/E48/E96 离散元件值和可用料号约束；
+- [ ] 单目标最优解和多目标 Pareto 候选；
+- [ ] 每轮修改、仿真、失败和停止原因进入可复现 manifest。
+
+首批基准电路：RC/RLC 滤波器、运放闭环电路、晶体管偏置和基础电源。
+找不到满足约束的候选时必须返回明确失败，不允许把最接近的候选标为通过。
+
+阶段门禁：至少三类基准电路能在固定预算内重复得到相同结论；每次修改
+都有原因、证据和回滚点；异常终止后能够恢复或安全结束。
+
+## 阶段 C：1.3 开放仿真后端
+
+- [ ] 接入 ngspice，支持 Linux/Docker 中的真实仿真；
+- [ ] 对相同 Circuit IR 执行 Multisim/ngspice 差分验证；
+- [ ] 记录 SPICE 方言、模型和求解器差异，而不是静默改写；
+- [ ] 将公共 CI 从 introspection-only 扩展到开放后端实验回归；
+- [ ] 按来源、许可证和 SHA-256 管理用户模型。
+
+阶段门禁：第二个后端无需改动优化器即可完成生成、仿真、测量和验证；
+跨后端误差有明确容差和诊断解释。
+
+## 阶段 D：可视化工作台
+
+第一版是本地只读工程审查器，不重造完整 EDA 编辑器。
+
+- [ ] 查看工程、原理图、波形、指标和报告；
+- [ ] 展示实验状态、优化收敛、敏感度和候选排名；
+- [ ] 比较两个设计版本及其 `DesignPatch`；
+- [ ] 在数据结构稳定后加入补丁审批、运行控制和回滚；
+- [ ] 主应用保持 64 位，Multisim worker 保持隔离的 32 位进程；
+- [ ] GUI 与 MCP 调用同一应用服务，不复制业务逻辑。
+
+阶段门禁：关闭并重新打开项目后能恢复完整工程状态；界面崩溃不会破坏
+实验队列；所有会覆盖工程的操作都需要明确审批。
+
+## 阶段 E：KiCad 与工程输出
+
+- [ ] 生成结构清晰的 KiCad 原理图；
+- [ ] 符号、封装和引脚映射具有来源记录；
+- [ ] 运行 ERC，导出 BOM、网表和预览；
+- [ ] 生成受约束的初始 PCB 工程；
+- [ ] 将 DRC、热、成本和可制造性约束纳入后续优化。
+
+自动 PCB 布局布线不属于初期承诺。没有 DRC、制造和人工审查证据时，
+不得把生成的 PCB 标记为可生产。
+
+## DeepSeek 与 Harness 主线
+
+DeepSeek API 是模型提供方；DeepSeek Harness 是代理运行时。适配分为：
+
+1. [x] MCP 客户端配置和 stdio 契约测试；
+2. [x] `core` / `experiment` / `optimization` / `full` Tool Profile；
+3. [x] 为不支持 MCP Resources 的客户端提供工具等价接口；
+4. [x] 为不支持 MCP Prompts 的客户端提供版本化 Harness Skill Bundle；
+5. [x] 建立机器可读版本门禁和非阻塞上游兼容监控；
+6. [x] 提供独立、带版本门禁的 DeepSeek Harness bundle 源码；
+7. [ ] 将 bundle 通过 Trusted Publishing 发布到 npm；
+8. [ ] 独立平台需要内置模型时，再实现通用 `ModelProvider` 和 DeepSeek provider。
+
+DeepSeek API Key 不得传给 Multisim MCP。Harness 当前处于 Developer Preview，
+集成测试应固定已验证版本，并用非阻塞的上游兼容任务监控新版本。
+
+## 不在近期范围内
+
+- “覆盖所有元器件”或来源不明的厂商模型自动下载；
+- 任意拓扑的无人审查自动重写；
+- 自研 SPICE 求解器、完整原理图编辑器或 PCB 路由器；
+- 把本地 stdio MCP 直接暴露到公网；
+- 将任何特定模型的响应格式写入 EDA Core。
+
+## English summary
+
+The post-1.0 plan keeps MCP as the primary interface while extracting a
+transport-neutral EDA and optimization core. Bounded diagnosis and parameter
+optimization come first, followed by an ngspice backend, a read-only visual
+workbench, and then KiCad engineering outputs. DeepSeek API support remains a
+model-provider concern; DeepSeek Harness support starts with MCP configuration,
+profiles, bounded artifact tools, a versioned skill bundle, and compatibility
+tests.

--- a/integrations/deepseek-harness/LICENSE
+++ b/integrations/deepseek-harness/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Multisim MCP contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -1,0 +1,39 @@
+# Multisim MCP 的 DeepSeek Harness 插件
+
+这是一个可独立安装的 Harness bundle。它把 Multisim MCP 注册为
+`mcp__multisim__*` 工具，并默认使用 `experiment` Tool Profile。
+
+## 本地安装
+
+先在 32 位 Python 中安装 `multisim-mcp`，然后设置该解释器路径：
+
+```powershell
+$env:MULTISIM_MCP_PYTHON = "C:\path\to\python32\python.exe"
+dsh plugin --profile web add .\integrations\deepseek-harness
+dsh --profile web --dump-config
+```
+
+在发布到 npm 后，可以把本地路径替换为
+`multisim-mcp-dsh-plugin@<version>`。当前源码包尚未发布到 npm。
+
+维护者发布前必须运行 Registry 与包边界守卫。首次发布需要本地 2FA；后续版本使用
+OIDC 暂存并由维护者 2FA 审批。完整步骤见
+[`docs/DEEPSEEK_HARNESS_NPM_RELEASE.md`](../../docs/DEEPSEEK_HARNESS_NPM_RELEASE.md)。
+
+可选环境变量：
+
+- `MULTISIM_MCP_TOOL_PROFILE`：`core`、`experiment`、`optimization` 或 `full`；
+- `MULTISIM_MCP_TEMPLATE_DIR`：本地组件模板包；
+- `MULTISIM_MCP_WORKDIR`：实验工作目录；
+- `MULTISIM_MCP_ARTIFACT_EXPORT_DIR`：允许导出产物的根目录。
+
+不要把 `DEEPSEEK_API_KEY` 放入 MCP 子进程配置。该凭据只属于 Harness。
+MCP 服务器命令在 agent 沙箱之外执行，应当只安装可信发布物并固定版本。
+
+## English summary
+
+This package is an installable DeepSeek Harness bundle for Multisim MCP. Set
+`MULTISIM_MCP_PYTHON` to the installed 32-bit Python interpreter before adding
+the bundle to a Harness profile. Model credentials remain in Harness and are
+never forwarded to the MCP child process. Maintainer release instructions are
+in `docs/DEEPSEEK_HARNESS_NPM_RELEASE.md`.

--- a/integrations/deepseek-harness/cordis.patch.yml
+++ b/integrations/deepseek-harness/cordis.patch.yml
@@ -1,0 +1,23 @@
+- id: "mcp-multisim"
+  name: "@deepseek-ai/dsh-mcp-client"
+  config:
+    serverName: "multisim"
+    transport: "stdio"
+    command: !!js process.env.MULTISIM_MCP_PYTHON ?? "python"
+    args:
+      - "-m"
+      - "multisim_mcp.server"
+    env:
+      PYTHONUTF8: "1"
+      PYTHONUNBUFFERED: "1"
+      MULTISIM_MCP_TOOL_PROFILE: !!js process.env.MULTISIM_MCP_TOOL_PROFILE ?? "experiment"
+      MULTISIM_MCP_TEMPLATE_DIR: !!js process.env.MULTISIM_MCP_TEMPLATE_DIR ?? ""
+      MULTISIM_MCP_WORKDIR: !!js process.env.MULTISIM_MCP_WORKDIR ?? ""
+      MULTISIM_MCP_ARTIFACT_EXPORT_DIR: !!js process.env.MULTISIM_MCP_ARTIFACT_EXPORT_DIR ?? ""
+    failOnStartupError: true
+    toolCallTimeoutMs: 120000
+    reconnect:
+      enabled: true
+      initialDelayMs: 500
+      maxDelayMs: 30000
+      maxAttempts: 10

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "multisim-mcp-dsh-plugin",
+  "version": "1.0.0",
+  "description": "DeepSeek Harness bundle for the Multisim MCP server",
+  "license": "MIT",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": "^22.19.0 || >=24.0.0"
+  },
+  "files": [
+    "cordis.patch.yml",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "dsh-plugin",
+    "deepseek-harness",
+    "mcp",
+    "multisim",
+    "eda"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yxy050208/multisim-mcp.git",
+    "directory": "integrations/deepseek-harness"
+  },
+  "homepage": "https://github.com/yxy050208/multisim-mcp#deepseek-harness",
+  "bugs": {
+    "url": "https://github.com/yxy050208/multisim-mcp/issues"
+  },
+  "dependencies": {
+    "@deepseek-ai/dsh-mcp-client": "0.1.0-rc.7"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  }
+}

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -165,6 +165,18 @@ C:\path\to\python32\Scripts\multisim-mcp.exe config `
   --python C:\path\to\python32\python.exe `
   --template-dir C:\MultisimMcp\component-pack
 
+# Official DeepSeek Harness Cordis plugin row
+C:\path\to\python32\Scripts\multisim-mcp.exe config `
+  --client deepseek-harness `
+  --python C:\path\to\python32\python.exe `
+  --template-dir C:\MultisimMcp\component-pack `
+  --work-dir C:\msre_exp `
+  --artifact-export-dir C:\MultisimMcp\exports `
+  --tool-profile experiment
+
+# Install the five bilingual workflow skills in a Harness project.
+C:\path\to\python32\Scripts\multisim-mcp.exe harness-skills --output .dsh/skills
+
 # Unwrapped command/args/env JSON for another stdio client
 C:\path\to\python32\Scripts\multisim-mcp.exe config --client generic
 ```
@@ -173,6 +185,21 @@ The generator previews content on stdout. `--output <new-file>` writes a
 fragment, refuses to overwrite by default, and accepts `--force` only when the
 caller explicitly wants replacement. It does not merge into a live client
 configuration.
+
+The Harness fragment uses `@deepseek-ai/dsh-mcp-client`, enforces the upstream
+1-32 character `serverName` rule, and never copies a DeepSeek API key into the
+MCP child process. See [`docs/DEEPSEEK_HARNESS.md`](../docs/DEEPSEEK_HARNESS.md).
+The same `--tool-profile core|experiment|optimization|full` option works for
+every generated client config. The default remains `full` for compatibility.
+`--artifact-export-dir` sets the only root beneath which the artifact export
+tool may write; without it, artifact export fails closed.
+`harness-skills` writes the packaged bundle to `.dsh/skills`, refuses existing
+files by default, and only replaces them when `--force` is explicit.
+Source-tree maintainers can run `python tools/check_deepseek_harness_compat.py
+--json` from the repository root to validate the pinned Harness contract.
+The independently installable Harness bundle lives in
+[`integrations/deepseek-harness`](../integrations/deepseek-harness) and currently
+supports local source installation; it is not yet published to npm.
 
 Manual MCP client configuration:
 

--- a/mcp_server/multisim_mcp/cli.py
+++ b/mcp_server/multisim_mcp/cli.py
@@ -14,12 +14,16 @@ from pathlib import Path
 from typing import Any, Sequence
 
 from multisim_mcp import __version__
+from multisim_mcp.experiment_resources import ARTIFACT_EXPORT_DIR_ENV
+from multisim_mcp.harness_skills import install_harness_skills
+from multisim_mcp.tool_profiles import TOOL_PROFILE_ENV, TOOL_PROFILES
 
 SCHEMA_VERSION = 1
 LOCAL_PACK_SCHEMA_VERSION = 2
 REQUIRED_TEMPLATES = ("minimal.ms14.xml", "wire.xml", "r_element.xml")
-CLIENTS = ("claude-desktop", "codex", "generic")
+CLIENTS = ("claude-desktop", "codex", "deepseek-harness", "generic")
 _SERVER_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_HARNESS_SERVER_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
 
 
 def _load_module(name: str) -> Any:
@@ -506,6 +510,8 @@ def _server_spec(
     python_executable: str,
     template_dir: str | None,
     work_dir: str | None,
+    tool_profile: str | None,
+    artifact_export_dir: str | None,
 ) -> dict[str, Any]:
     def normalize(value: str) -> str:
         return os.path.abspath(os.path.expanduser(value))
@@ -518,6 +524,13 @@ def _server_spec(
         if " " in resolved_work_dir:
             raise ValueError("work directory must not contain spaces")
         environment["MULTISIM_MCP_WORKDIR"] = resolved_work_dir
+    if tool_profile:
+        environment[TOOL_PROFILE_ENV] = tool_profile
+    if artifact_export_dir:
+        resolved_export_dir = Path(normalize(artifact_export_dir))
+        if resolved_export_dir == Path(resolved_export_dir.anchor):
+            raise ValueError("artifact export directory must not be a filesystem root")
+        environment[ARTIFACT_EXPORT_DIR_ENV] = str(resolved_export_dir)
     result: dict[str, Any] = {
         "command": normalize(python_executable),
         "args": ["-m", "multisim_mcp.server"],
@@ -531,12 +544,56 @@ def _toml_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
+def _render_deepseek_harness_config(
+    server_name: str, spec: dict[str, Any]
+) -> str:
+    """Render a Cordis plugin row for the official DeepSeek Harness MCP client."""
+    if not _HARNESS_SERVER_NAME_RE.fullmatch(server_name):
+        raise ValueError(
+            "DeepSeek Harness server name must be 1-32 characters and contain "
+            "only letters, digits, underscore, and hyphen"
+        )
+
+    # JSON string literals are valid YAML scalars and avoid path escaping bugs on
+    # Windows. Keep this fragment dependency-free so it works in the 32-bit host.
+    lines = [
+        f"- id: {_toml_string(f'mcp-{server_name}')}",
+        '  name: "@deepseek-ai/dsh-mcp-client"',
+        "  config:",
+        f"    serverName: {_toml_string(server_name)}",
+        '    transport: "stdio"',
+        f"    command: {_toml_string(spec['command'])}",
+        "    args:",
+    ]
+    lines.extend(f"      - {_toml_string(item)}" for item in spec["args"])
+    if spec.get("env"):
+        lines.append("    env:")
+        lines.extend(
+            f"      {key}: {_toml_string(value)}"
+            for key, value in sorted(spec["env"].items())
+        )
+    lines.extend(
+        [
+            "    failOnStartupError: true",
+            "    toolCallTimeoutMs: 120000",
+            "    reconnect:",
+            "      enabled: true",
+            "      initialDelayMs: 500",
+            "      maxDelayMs: 30000",
+            "      maxAttempts: 10",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
 def render_client_config(
     client: str,
     server_name: str = "multisim",
     python_executable: str | None = None,
     template_dir: str | None = None,
     work_dir: str | None = None,
+    tool_profile: str | None = None,
+    artifact_export_dir: str | None = None,
 ) -> str:
     """Render a copy-pasteable MCP client configuration fragment."""
     if client not in CLIENTS:
@@ -545,7 +602,17 @@ def render_client_config(
         raise ValueError(
             "server name may contain only letters, digits, dot, underscore, and hyphen"
         )
-    spec = _server_spec(python_executable or sys.executable, template_dir, work_dir)
+    if tool_profile is not None and tool_profile not in TOOL_PROFILES:
+        raise ValueError(f"unsupported tool profile: {tool_profile}")
+    spec = _server_spec(
+        python_executable or sys.executable,
+        template_dir,
+        work_dir,
+        tool_profile,
+        artifact_export_dir,
+    )
+    if client == "deepseek-harness":
+        return _render_deepseek_harness_config(server_name, spec)
     if client == "codex":
         lines = [
             f"[mcp_servers.{server_name}]",
@@ -638,11 +705,41 @@ def build_parser() -> argparse.ArgumentParser:
     config.add_argument(
         "--work-dir", help="space-free Multisim experiment work directory"
     )
+    config.add_argument(
+        "--tool-profile",
+        choices=TOOL_PROFILES,
+        help="limit tools/list to a task-oriented profile (default: full)",
+    )
+    config.add_argument(
+        "--artifact-export-dir",
+        help="approved root for export_experiment_artifact",
+    )
     config.add_argument("--output", help="write the fragment to this file")
     config.add_argument(
         "--force", action="store_true", help="replace an existing output file"
     )
     config.add_argument(
+        "--json",
+        dest="json_command",
+        action="store_true",
+        help="emit a JSON result envelope",
+    )
+
+    harness_skills = subparsers.add_parser(
+        "harness-skills",
+        help="install the bundled DeepSeek Harness skills into a project",
+    )
+    harness_skills.add_argument(
+        "--output",
+        default=".dsh/skills",
+        help="Harness skill discovery root (default: .dsh/skills)",
+    )
+    harness_skills.add_argument(
+        "--force",
+        action="store_true",
+        help="replace existing copies of the five bundled skills",
+    )
+    harness_skills.add_argument(
         "--json",
         dest="json_command",
         action="store_true",
@@ -675,6 +772,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             _print_doctor_human(report)
         return 1 if args.strict and not report["full_workflow_ready"] else 0
+    if args.command == "harness-skills":
+        try:
+            result = install_harness_skills(args.output, force=args.force)
+        except (OSError, ValueError) as exc:
+            if json_output:
+                print(
+                    json.dumps(
+                        {
+                            "schema_version": SCHEMA_VERSION,
+                            "command": "harness-skills",
+                            "success": False,
+                            "error": {"type": type(exc).__name__, "message": str(exc)},
+                        },
+                        ensure_ascii=False,
+                    )
+                )
+            else:
+                parser.error(str(exc))
+            return 2
+        if json_output:
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+        else:
+            print(result["output_dir"])
+        return 0
     if args.command == "config":
         try:
             content = render_client_config(
@@ -683,6 +804,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 python_executable=args.python,
                 template_dir=args.template_dir,
                 work_dir=args.work_dir,
+                tool_profile=args.tool_profile,
+                artifact_export_dir=args.artifact_export_dir,
             )
             output = (
                 _write_config(args.output, content, args.force) if args.output else None

--- a/mcp_server/multisim_mcp/experiment_resources.py
+++ b/mcp_server/multisim_mcp/experiment_resources.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
+import shutil
 import threading
+import uuid
 from pathlib import Path
 from typing import Any, Final
 
 from typing_extensions import TypedDict
+
+from multisim_mcp.spice_raw import parse_raw, summarize_columns
 
 
 class ArtifactDescriptor(TypedDict):
@@ -55,6 +60,8 @@ class VerifiedExperimentResult(ExperimentResult):
 _RESOURCE_SCHEME: Final = "multisim://experiments"
 _EXPERIMENT_ID_PATTERN: Final = re.compile(r"^exp-[0-9a-f]{24}$")
 _DEFAULT_MAX_RESOURCE_BYTES: Final = 16 * 1024 * 1024
+_MAX_TEXT_PAGE_CHARS: Final = 100_000
+ARTIFACT_EXPORT_DIR_ENV: Final = "MULTISIM_MCP_ARTIFACT_EXPORT_DIR"
 
 # Logical names are intentionally fixed. A model cannot turn a resource URI into
 # an arbitrary local-file read by supplying path separators or a different name.
@@ -258,6 +265,234 @@ def experiment_manifest(experiment_id: str) -> dict[str, Any]:
         "schema_version": 1,
         "experiment_id": experiment_id,
         "artifacts": artifacts,
+    }
+
+
+def list_artifacts(experiment_id: str) -> dict[str, Any]:
+    """List registered artifacts with bounded-read and export capabilities."""
+    manifest = experiment_manifest(experiment_id)
+    artifacts: list[dict[str, Any]] = []
+    for descriptor in manifest["artifacts"]:
+        definition = _ARTIFACTS.get(descriptor["name"])
+        artifacts.append(
+            {
+                **descriptor,
+                "text_readable": bool(definition and not definition[2]),
+                "exportable": definition is not None,
+            }
+        )
+    return {
+        "schema_version": 1,
+        "experiment_id": experiment_id,
+        "artifact_count": len(artifacts),
+        "total_size": sum(int(item["size"]) for item in artifacts),
+        "artifacts": artifacts,
+    }
+
+
+def read_artifact_page(
+    experiment_id: str,
+    name: str,
+    offset: int = 0,
+    max_chars: int = 20_000,
+) -> dict[str, Any]:
+    """Read a bounded character page from an allowlisted text artifact."""
+    if offset < 0:
+        raise ValueError("offset must not be negative")
+    if max_chars < 1 or max_chars > _MAX_TEXT_PAGE_CHARS:
+        raise ValueError(
+            f"max_chars must be between 1 and {_MAX_TEXT_PAGE_CHARS}"
+        )
+    content = read_text_artifact(experiment_id, name)
+    page = content[offset : offset + max_chars]
+    next_offset = offset + len(page)
+    truncated = next_offset < len(content)
+    definition = _ARTIFACTS[name]
+    return {
+        "schema_version": 1,
+        "experiment_id": experiment_id,
+        "name": name,
+        "mime_type": definition[1],
+        "offset": offset,
+        "next_offset": next_offset if truncated else None,
+        "total_chars": len(content),
+        "truncated": truncated,
+        "content": page,
+    }
+
+
+def export_artifact(
+    experiment_id: str,
+    name: str,
+    destination_subdir: str = "",
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Copy one allowlisted artifact beneath an explicitly approved root."""
+    definition = _ARTIFACTS.get(name)
+    if definition is None:
+        raise ValueError(f"Unknown experiment artifact: {name}")
+    configured_root = os.environ.get(ARTIFACT_EXPORT_DIR_ENV, "").strip()
+    if not configured_root:
+        raise RuntimeError(
+            f"Set {ARTIFACT_EXPORT_DIR_ENV} to an approved export directory"
+        )
+    export_root = Path(configured_root).expanduser().resolve()
+    if export_root == Path(export_root.anchor):
+        raise ValueError("artifact export directory must not be a filesystem root")
+
+    relative = Path(destination_subdir or ".")
+    if relative.is_absolute():
+        raise ValueError("destination_subdir must be relative to the export directory")
+    destination_dir = (export_root / relative).resolve()
+    try:
+        destination_dir.relative_to(export_root)
+    except ValueError as exc:
+        raise ValueError("destination_subdir escapes the export directory") from exc
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    source = _safe_artifact(_registered_root(experiment_id), definition[0])
+    destination = destination_dir / definition[0]
+    if source == destination:
+        raise ValueError("artifact source and export destination must differ")
+    if destination.is_symlink() or (destination.exists() and not destination.is_file()):
+        raise ValueError("artifact export destination must be a regular file")
+    if destination.exists() and not overwrite:
+        raise FileExistsError(f"artifact export destination exists: {destination}")
+
+    temporary = destination_dir / f".{destination.name}.{uuid.uuid4().hex}.tmp"
+    try:
+        shutil.copy2(source, temporary)
+        os.replace(temporary, destination)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return {
+        "schema_version": 1,
+        "success": True,
+        "experiment_id": experiment_id,
+        "name": name,
+        "mime_type": definition[1],
+        "size": destination.stat().st_size,
+        "sha256": _sha256_file(destination),
+        "destination": str(destination),
+    }
+
+
+def summarize_experiment(experiment_id: str) -> dict[str, Any]:
+    """Return a compact Tool-friendly summary without binary artifact content."""
+    listing = list_artifacts(experiment_id)
+    report = read_artifact_page(experiment_id, "report", max_chars=4_000)
+    artifact_names = {item["name"] for item in listing["artifacts"]}
+    root = _registered_root(experiment_id)
+    raw_path = _safe_artifact(root, _ARTIFACTS["raw"][0])
+    measurement_summary: dict[str, Any]
+    if raw_path.stat().st_size > _resource_limit():
+        measurement_summary = {
+            "available": False,
+            "error": "raw artifact exceeds the configured resource limit",
+        }
+    else:
+        try:
+            parsed_raw = parse_raw(str(raw_path))
+            columns = summarize_columns(parsed_raw)
+            measurement_summary = {
+                "available": True,
+                "plotname": parsed_raw.get("header", {}).get("plotname", ""),
+                "point_count": parsed_raw.get("n_points", 0),
+                "column_count": len(columns),
+                "columns": columns[:64],
+                "columns_truncated": len(columns) > 64,
+            }
+        except (OSError, ValueError) as exc:
+            measurement_summary = {
+                "available": False,
+                "error": str(exc)[:500],
+            }
+    verification: dict[str, Any] | None = None
+    if "verification" in artifact_names:
+        text = read_text_artifact(experiment_id, "verification")
+        try:
+            parsed = json.loads(text)
+            if not isinstance(parsed, dict):
+                raise ValueError("verification root must be an object")
+            raw_requirements = parsed.get("requirements", [])
+            requirements = raw_requirements if isinstance(raw_requirements, list) else []
+            compact_requirements: list[dict[str, Any]] = []
+            allowed_fields = (
+                "id",
+                "status",
+                "value",
+                "unit",
+                "operator",
+                "target",
+                "lower",
+                "upper",
+                "reason",
+            )
+            for raw in requirements[:25]:
+                if not isinstance(raw, dict):
+                    continue
+                item = {key: raw[key] for key in allowed_fields if key in raw}
+                for key, value in list(item.items()):
+                    if not isinstance(value, (str, int, float, bool, type(None))):
+                        del item[key]
+                    elif isinstance(value, str) and len(value) > 500:
+                        item[key] = value[:500] + "..."
+                compact_requirements.append(item)
+            raw_counts = parsed.get("counts")
+            compact_counts = (
+                {
+                    key: value
+                    for key in ("pass", "fail", "unverified")
+                    if isinstance((value := raw_counts.get(key)), int)
+                }
+                if isinstance(raw_counts, dict)
+                else None
+            )
+            schema_version = parsed.get("schema_version")
+            overall_status = parsed.get("overall_status")
+            verification = {
+                "available": True,
+                "valid_json": True,
+                "result": {
+                    "schema_version": (
+                        schema_version if isinstance(schema_version, int) else None
+                    ),
+                    "overall_status": (
+                        str(overall_status)[:50]
+                        if overall_status is not None
+                        else None
+                    ),
+                    "counts": compact_counts,
+                    "requirement_count": len(requirements),
+                    "requirements": compact_requirements,
+                    "requirements_truncated": len(requirements) > 25,
+                },
+            }
+        except (json.JSONDecodeError, ValueError) as exc:
+            verification = {
+                "available": True,
+                "valid_json": False,
+                "error": str(exc),
+            }
+    return {
+        "schema_version": 1,
+        "experiment_id": experiment_id,
+        "artifact_count": listing["artifact_count"],
+        "total_size": listing["total_size"],
+        "report_excerpt": report["content"],
+        "report_truncated": report["truncated"],
+        "measurements": measurement_summary,
+        "verification": verification or {"available": False},
+        "artifacts": [
+            {
+                "name": item["name"],
+                "mime_type": item["mime_type"],
+                "size": item["size"],
+                "sha256": item["sha256"],
+            }
+            for item in listing["artifacts"]
+        ],
     }
 
 

--- a/mcp_server/multisim_mcp/harness_skills.py
+++ b/mcp_server/multisim_mcp/harness_skills.py
@@ -1,0 +1,124 @@
+"""Versioned DeepSeek Harness skill bundle and safe installer."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+
+_SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def _bundle_root() -> Any:
+    return files("multisim_mcp").joinpath("harness_skills")
+
+
+def bundled_harness_skill_manifest() -> dict[str, Any]:
+    """Load and validate the packaged Harness skill manifest."""
+    root = _bundle_root()
+    payload = json.loads(root.joinpath("manifest.json").read_text(encoding="utf-8"))
+    if payload.get("schema_version") != 1:
+        raise ValueError("unsupported Harness skill manifest schema")
+    names = payload.get("skills")
+    if not isinstance(names, list) or not names:
+        raise ValueError("Harness skill manifest must contain a non-empty skills list")
+    if len(set(names)) != len(names):
+        raise ValueError("Harness skill manifest contains duplicate names")
+    for name in names:
+        if not isinstance(name, str) or not _SKILL_NAME_RE.fullmatch(name):
+            raise ValueError(f"invalid Harness skill name: {name!r}")
+        content = root.joinpath(name, "SKILL.md").read_text(encoding="utf-8")
+        if not content.startswith("---\n") or f"\nname: {name}\n" not in content:
+            raise ValueError(f"Harness skill frontmatter does not match: {name}")
+    return payload
+
+
+def bundled_harness_skills() -> dict[str, str]:
+    """Return the validated immutable skill bodies keyed by skill name."""
+    manifest = bundled_harness_skill_manifest()
+    root = _bundle_root()
+    return {
+        name: root.joinpath(name, "SKILL.md").read_text(encoding="utf-8")
+        for name in manifest["skills"]
+    }
+
+
+def install_harness_skills(
+    output_dir: str = ".dsh/skills", force: bool = False
+) -> dict[str, Any]:
+    """Install the bundle without silently replacing existing project skills."""
+    if not output_dir.strip():
+        raise ValueError("Harness skill output directory must not be empty")
+    requested_root = Path(output_dir).expanduser()
+    if requested_root.is_symlink():
+        raise ValueError("Harness skill output must not be a symbolic link")
+    root = requested_root.resolve()
+    if root == Path(root.anchor):
+        raise ValueError("Harness skill output directory must not be a filesystem root")
+    if root.exists() and not root.is_dir():
+        raise ValueError("Harness skill output must be a regular directory")
+
+    manifest = bundled_harness_skill_manifest()
+    skills = bundled_harness_skills()
+    destinations = {name: root / name / "SKILL.md" for name in skills}
+    for destination in destinations.values():
+        parent = destination.parent
+        if parent.is_symlink() or (parent.exists() and not parent.is_dir()):
+            raise ValueError(
+                f"Harness skill directory must be a regular directory: {parent}"
+            )
+        if parent.exists():
+            try:
+                parent.resolve().relative_to(root)
+            except ValueError as exc:
+                raise ValueError(
+                    "Harness skill destination escapes the output root"
+                ) from exc
+        if destination.is_symlink() or (
+            destination.exists() and not destination.is_file()
+        ):
+            raise ValueError(
+                f"Harness skill destination must be a regular file: {destination}"
+            )
+        if destination.exists() and not force:
+            raise FileExistsError(
+                "Harness skill already exists; pass --force to replace the bundle: "
+                f"{destination}"
+            )
+
+    installed: list[str] = []
+    for name, content in skills.items():
+        destination = destinations[name]
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        resolved_parent = destination.parent.resolve()
+        try:
+            resolved_parent.relative_to(root)
+        except ValueError as exc:
+            raise ValueError("Harness skill destination escapes the output root") from exc
+        temporary = destination.parent / f".SKILL.md.{uuid.uuid4().hex}.tmp"
+        try:
+            with temporary.open("x", encoding="utf-8", newline="\n") as handle:
+                handle.write(content)
+            os.replace(temporary, destination)
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+        installed.append(str(destination))
+
+    return {
+        "schema_version": 1,
+        "command": "harness-skills",
+        "success": True,
+        "bundle_name": manifest["bundle_name"],
+        "bundle_version": manifest["bundle_version"],
+        "output_dir": str(root),
+        "force": force,
+        "skill_count": len(installed),
+        "skills": list(skills),
+        "installed": installed,
+    }

--- a/mcp_server/multisim_mcp/harness_skills/manifest.json
+++ b/mcp_server/multisim_mcp/harness_skills/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "bundle_name": "multisim-mcp-harness-skills",
+  "bundle_version": 1,
+  "upstream": {
+    "repository": "https://github.com/deepseek-ai/deepseek-harness",
+    "verified_date": "2026-08-18",
+    "discovery_root": ".dsh/skills"
+  },
+  "skills": [
+    "multisim-create-experiment",
+    "multisim-debug-circuit",
+    "multisim-compare-experiments",
+    "multisim-write-lab-report",
+    "multisim-verify-requirements"
+  ]
+}

--- a/mcp_server/multisim_mcp/harness_skills/multisim-compare-experiments/SKILL.md
+++ b/mcp_server/multisim_mcp/harness_skills/multisim-compare-experiments/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: multisim-compare-experiments
+description: 比较两个已注册 Multisim 实验的电路、设置、测量、验证和产物；use when evaluating a baseline against a candidate or explaining changed simulation results
+---
+
+# 比较 Multisim 实验
+
+需要两个已注册实验 ID。工具名为 Multisim MCP 原始名；Harness 通常添加
+`mcp__multisim__` 前缀。
+
+1. 分别调用 `get_experiment_summary`，确认两个 ID 可用并记录产物哈希。
+2. 按需调用 `read_experiment_artifact` 分页读取 `netlist`、`commands`、`report`、
+   `verification` 或 `data`。只读取解释差异所需的最小内容。
+3. 比较电路拓扑与参数、分析命令、采样点、关键列的首值/末值/最小值/最大值/均值、
+   验证状态和产物 SHA-256。
+4. 区分设计变化、求解设置变化、采样差异和证据缺失。不要把相关性写成因果关系。
+5. 如果两次实验的分析条件不可比，明确标记“不可直接比较”，并说明需要怎样的复测。
+
+最终给出紧凑表格，至少包含指标、实验 A、实验 B、差值/变化率、证据和结论，随后
+列出最可能原因与仍未验证的假设。除非用户明确要求，不导出二进制产物。
+
+## English summary
+
+Compare two registered experiments using bounded summaries and only the text
+pages needed to explain topology, settings, measurements, verdicts, and hashes.
+Flag incompatible test conditions instead of forcing a conclusion.

--- a/mcp_server/multisim_mcp/harness_skills/multisim-create-experiment/SKILL.md
+++ b/mcp_server/multisim_mcp/harness_skills/multisim-create-experiment/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: multisim-create-experiment
+description: 根据工程要求生成安全、可复现的 Multisim 电路实验并核对理论与仿真结果；use when creating a new circuit, schematic, simulation, or experiment report
+---
+
+# 创建 Multisim 电路实验
+
+本 skill 使用 Multisim MCP 工具。下文写原始工具名；DeepSeek Harness 默认会将其
+显示为 `mcp__multisim__<工具名>`，如果配置使用了不同 `serverName`，请采用实际前缀。
+
+1. 收集电路功能、输入输出、供电、频率、容差、分析类型、输出目录和验收指标。
+   对会改变设计结论的缺失条件先向用户确认。
+2. 调用 `runtime_status`。完整工作流未就绪时，报告具体缺口，不要反复尝试 COM。
+3. 以 SPICE 网表作为源数据。只使用受支持元件和 `op`、`dc`、`ac`、`tran` 分析；
+   禁止任意命令、外部文件模型和来源不明的器件模型。
+4. 有明确验收指标时优先调用 `run_verified_circuit_experiment`；普通实验调用
+   `run_circuit_experiment`，长任务调用 `submit_circuit_experiment` 并查询任务状态。
+5. 成功后调用 `get_experiment_summary` 和 `list_experiment_artifacts`。只有需要更多
+   文本证据时才分页调用 `read_experiment_artifact`，不要读取二进制内容。
+6. 核对理论值、仿真测量、容差和验证结论。任何缺少数据支持的指标标记为“未验证”。
+7. 仅在用户要求导出时调用 `export_experiment_artifact`；导出目录必须已由服务端批准。
+
+最终答复应列出电路假设、网表/分析、关键测量、PASS/FAIL/未验证结论和产物清单。
+不要把“最接近要求”写成“通过”，也不要声称自动生成的设计已可直接生产。
+
+## English summary
+
+Create a reproducible experiment from explicit requirements, prefer verified or
+durable high-level tools, inspect bounded artifact summaries, and report only
+claims supported by simulation evidence.

--- a/mcp_server/multisim_mcp/harness_skills/multisim-debug-circuit/SKILL.md
+++ b/mcp_server/multisim_mcp/harness_skills/multisim-debug-circuit/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: multisim-debug-circuit
+description: 诊断并以最小、可回滚修改修复 Multisim 电路或仿真故障；use for invalid netlists, convergence failures, wrong waveforms, bias errors, or missing outputs
+---
+
+# 调试 Multisim 电路
+
+本 skill 引用 Multisim MCP 原始工具名；Harness 默认前缀为 `mcp__multisim__`。
+
+1. 保存问题描述、原始网表、分析命令、错误日志和已有实验 ID，不覆盖原始设计。
+2. 调用 `runtime_status`，把安装/COM/模板故障与电路故障分开。
+3. 按顺序检查：网表语法、地节点、悬空节点、短路、极性、单位、偏置、模型、
+   分析命令、采样范围、饱和以及收敛条件。
+4. 若有实验 ID，先用 `get_experiment_summary`，再按需读取 `log`、`netlist`、
+   `commands` 或 `report`；不要把二进制文件送入模型上下文。
+5. 提出能够解释故障的最小修改，明确修改前值、修改后值、理由和回滚方法。
+6. 在新的输出目录重新运行，禁止启用 `do_command_line` 或不安全命令模式。
+7. 使用 `get_experiment_summary` 比较修复前后测量；若证据仍不足，保留“未验证”。
+
+输出采用“症状—证据—根因—最小修改—复测结果—剩余风险”结构。不要在没有
+复测数据时宣称问题已经解决。
+
+## English summary
+
+Separate environment failures from circuit defects, inspect bounded evidence,
+apply the smallest reversible change, rerun into a new output directory, and
+compare measured results before declaring the issue fixed.

--- a/mcp_server/multisim_mcp/harness_skills/multisim-verify-requirements/SKILL.md
+++ b/mcp_server/multisim_mcp/harness_skills/multisim-verify-requirements/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: multisim-verify-requirements
+description: 将电路设计要求转成可计算判据并依据实验数据给出 PASS、FAIL 或未验证；use for acceptance testing, tolerance checks, and evidence-backed design review
+---
+
+# 验证 Multisim 设计要求
+
+需要实验 ID 和设计要求。工具名为 Multisim MCP 原始名；Harness 通常添加
+`mcp__multisim__` 前缀。
+
+1. 调用 `get_experiment_summary`，确认测量列、分析类型和现有验证结果。
+2. 把每一项要求转换为独立、稳定的 requirement ID、测量 metric、signal、operator、
+   target 或上下界、容差和单位。不得把定性目标伪装成可测量数值。
+3. 调用 `verify_experiment_requirements`；有理论值时通过 `theoretical_values` 提供，
+   不从模型猜测理论值。
+4. 对每项列出原要求、判据、实测值、目标、容差、状态和证据。工具返回
+   `unverified` 时保持该状态，不以最接近值代替通过。
+5. 若失败源于测量列或分析设置不足，提出最小复测计划；除非用户授权，不自动覆盖
+   原实验或修改电路。
+
+结论必须同时给出整体状态和 pass/fail/unverified 计数。任何无法从数据证明的安全、
+可靠性、热或可制造性声明都不属于仿真通过项。
+
+## English summary
+
+Translate each requirement into an explicit measurable criterion, call the
+verification tool, preserve unverified outcomes, and propose a minimal rerun
+when the existing analysis cannot supply the required evidence.

--- a/mcp_server/multisim_mcp/harness_skills/multisim-write-lab-report/SKILL.md
+++ b/mcp_server/multisim_mcp/harness_skills/multisim-write-lab-report/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: multisim-write-lab-report
+description: 基于已注册实验的真实产物撰写中英实验报告；use when producing a lab report, design record, reproducibility package, or formal HTML/PDF output
+---
+
+# 撰写 Multisim 实验报告
+
+只使用已注册实验的证据。工具名为 Multisim MCP 原始名；Harness 通常添加
+`mcp__multisim__` 前缀。
+
+1. 调用 `get_experiment_summary` 和 `list_experiment_artifacts`。
+2. 分页读取 `report`、`netlist`、`commands`、`data` 和 `verification` 中实际需要的
+   文本。不得编造缺失测量，也不要在上下文内请求 PDF、PNG、raw 或 `.ms14`。
+3. 报告包含：目的、设计要求、原理、器件与参数、分析设置、步骤、关键数据、
+   理论对比、误差、验证结果、异常、局限、结论和复现产物 SHA-256。
+4. 将事实、计算结果和工程判断分开。所有 PASS/FAIL 引用验证证据；不支持的指标
+   标为“未验证”。
+5. 用户需要正式文件时调用 `export_formal_experiment_report`；用户需要把文件复制到
+   其他位置时再调用 `export_experiment_artifact`，且不得绕过批准的导出根目录。
+
+默认中文为主并附英文摘要；用户指定英文时反向处理。报告中的本地文件引用应来自
+工具返回值，不猜测路径。
+
+## English summary
+
+Write a traceable report from registered artifacts, measured summaries, and
+verification evidence. Keep facts, calculations, and engineering judgment
+separate, and use formal export tools only when requested.

--- a/mcp_server/multisim_mcp/server.py
+++ b/mcp_server/multisim_mcp/server.py
@@ -24,12 +24,16 @@ from multisim_mcp.experiment_resources import (
     ExperimentResourceIndex,
     ExperimentResult,
     VerifiedExperimentResult,
+    export_artifact as export_registered_artifact,
     experiment_manifest,
     experiment_id_for_output_dir,
+    list_artifacts,
+    read_artifact_page,
     read_binary_artifact,
     read_text_artifact,
     register_experiment,
     registered_experiment_root,
+    summarize_experiment,
 )
 from multisim_mcp.component_adapters import (
     component_adapter_catalog as adapter_catalog,
@@ -76,10 +80,16 @@ from multisim_mcp.sweep_resources import (
     read_sweep_text,
     register_sweep,
 )
+from multisim_mcp.tool_profiles import (
+    selected_tool_profile,
+    tool_enabled,
+    tool_profile_status,
+)
 
 
 _COM_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="multisim-com")
 _COM_THREAD_STATE = threading.local()
+_TOOL_PROFILE = selected_tool_profile()
 
 
 def _invoke_tool_on_com_thread(function: Any, args: tuple, kwargs: dict) -> Any:
@@ -104,6 +114,10 @@ class MultisimMCPServer(MCPServer):
         register = super().tool(*decorator_args, **decorator_kwargs)
 
         def decorator(function: Any) -> Any:
+            if not tool_enabled(function.__name__, _TOOL_PROFILE):
+                # Keep the original callable available to internal code and unit
+                # tests while omitting it from MCP tools/list for this process.
+                return function
             if not com_serialized:
                 register(function)
                 return function
@@ -521,6 +535,7 @@ def runtime_status() -> dict:
     ]
     result["schematic_templates_ready"] = not missing
     result["missing_schematic_templates"] = missing
+    result["tool_profile"] = tool_profile_status(_TOOL_PROFILE)
     if missing:
         result["template_setup_hint"] = (
             "Run tools/bootstrap_local_component_pack.py and set "
@@ -537,6 +552,42 @@ def register_experiment_artifacts(output_dir: str) -> ExperimentResourceIndex:
     Only the fixed high-level experiment artifact set is exposed.
     """
     return register_experiment(output_dir)
+
+
+@mcp.tool(com_serialized=False)
+def list_experiment_artifacts(experiment_id: str) -> dict[str, Any]:
+    """List artifact metadata, hashes, MIME types, and safe access capabilities."""
+    return list_artifacts(experiment_id)
+
+
+@mcp.tool(com_serialized=False)
+def read_experiment_artifact(
+    experiment_id: str,
+    name: str,
+    offset: int = 0,
+    max_chars: int = 20_000,
+) -> dict[str, Any]:
+    """Read one bounded page from an allowlisted text experiment artifact."""
+    return read_artifact_page(experiment_id, name, offset, max_chars)
+
+
+@mcp.tool(com_serialized=False)
+def export_experiment_artifact(
+    experiment_id: str,
+    name: str,
+    destination_subdir: str = "",
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Export an artifact beneath MULTISIM_MCP_ARTIFACT_EXPORT_DIR."""
+    return export_registered_artifact(
+        experiment_id, name, destination_subdir, overwrite
+    )
+
+
+@mcp.tool(com_serialized=False)
+def get_experiment_summary(experiment_id: str) -> dict[str, Any]:
+    """Return a compact report, verification, and artifact summary for agents."""
+    return summarize_experiment(experiment_id)
 
 
 @mcp.tool(com_serialized=False)

--- a/mcp_server/multisim_mcp/tool_profiles.py
+++ b/mcp_server/multisim_mcp/tool_profiles.py
@@ -1,0 +1,223 @@
+"""Stable tool-discovery profiles for MCP clients with limited context."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+
+TOOL_PROFILE_ENV = "MULTISIM_MCP_TOOL_PROFILE"
+TOOL_PROFILES = ("core", "experiment", "optimization", "full")
+
+ALL_TOOL_NAMES = frozenset(
+    {
+        "connect",
+        "runtime_status",
+        "register_experiment_artifacts",
+        "list_experiment_artifacts",
+        "read_experiment_artifact",
+        "export_experiment_artifact",
+        "get_experiment_summary",
+        "register_sweep_artifacts",
+        "measure_experiment",
+        "read_virtual_multimeter",
+        "analyze_bode_response",
+        "analyze_logic_signals",
+        "export_formal_experiment_report",
+        "component_adapter_catalog",
+        "verify_experiment_requirements",
+        "plan_experiment_sweep",
+        "submit_circuit_experiment",
+        "get_experiment_job",
+        "list_experiment_jobs",
+        "cancel_experiment_job",
+        "retry_experiment_job",
+        "schematic_component_catalog",
+        "disconnect",
+        "open_circuit",
+        "new_circuit",
+        "circuit_info",
+        "enum_components",
+        "enum_inputs",
+        "enum_outputs",
+        "set_output_request",
+        "get_output_data",
+        "run_transient",
+        "run_dc_operating_point",
+        "run_ac_sweep",
+        "run_ac_single_frequency",
+        "set_input_data_sampled",
+        "set_input_data_raw",
+        "clear_input_data",
+        "stop_simulation",
+        "save_circuit",
+        "get_circuit_image",
+        "report_netlist",
+        "report_bom",
+        "do_command_line",
+        "run_spice_netlist",
+        "create_schematic_from_netlist",
+        "run_circuit_experiment",
+        "run_verified_circuit_experiment",
+        "run_experiment_sweep",
+        "submit_experiment_sweep",
+        "generate_report",
+        "get_rlc_value",
+        "set_rlc_value",
+        "decode_ms14",
+        "encode_ms14",
+    }
+)
+
+_COMMON = frozenset({"runtime_status", "connect", "disconnect"})
+
+_CIRCUIT_CORE = frozenset(
+    {
+        "component_adapter_catalog",
+        "schematic_component_catalog",
+        "open_circuit",
+        "new_circuit",
+        "circuit_info",
+        "enum_components",
+        "enum_inputs",
+        "enum_outputs",
+        "save_circuit",
+        "get_circuit_image",
+        "report_netlist",
+        "report_bom",
+        "get_rlc_value",
+        "set_rlc_value",
+        "decode_ms14",
+        "encode_ms14",
+    }
+)
+
+_BASIC_SIMULATION = frozenset(
+    {
+        "set_output_request",
+        "get_output_data",
+        "run_transient",
+        "run_dc_operating_point",
+        "run_ac_sweep",
+        "run_ac_single_frequency",
+        "stop_simulation",
+    }
+)
+
+_EXPERIMENT_WORKFLOW = frozenset(
+    {
+        "register_experiment_artifacts",
+        "measure_experiment",
+        "read_virtual_multimeter",
+        "analyze_bode_response",
+        "analyze_logic_signals",
+        "export_formal_experiment_report",
+        "verify_experiment_requirements",
+        "submit_circuit_experiment",
+        "get_experiment_job",
+        "list_experiment_jobs",
+        "cancel_experiment_job",
+        "retry_experiment_job",
+        "create_schematic_from_netlist",
+        "run_circuit_experiment",
+        "run_verified_circuit_experiment",
+        "generate_report",
+    }
+)
+
+_ARTIFACT_WORKFLOW = frozenset(
+    {
+        "list_experiment_artifacts",
+        "read_experiment_artifact",
+        "export_experiment_artifact",
+        "get_experiment_summary",
+    }
+)
+
+_SWEEP_WORKFLOW = frozenset(
+    {
+        "register_sweep_artifacts",
+        "plan_experiment_sweep",
+        "run_experiment_sweep",
+        "submit_experiment_sweep",
+    }
+)
+
+_OPTIMIZATION_WORKFLOW = frozenset(
+    {
+        "component_adapter_catalog",
+        "schematic_component_catalog",
+        "open_circuit",
+        "circuit_info",
+        "enum_components",
+        "get_circuit_image",
+        "report_netlist",
+        "report_bom",
+        "get_rlc_value",
+        "set_rlc_value",
+        "register_experiment_artifacts",
+        "measure_experiment",
+        "analyze_bode_response",
+        "verify_experiment_requirements",
+        "submit_circuit_experiment",
+        "get_experiment_job",
+        "list_experiment_jobs",
+        "cancel_experiment_job",
+        "retry_experiment_job",
+        "create_schematic_from_netlist",
+        "run_circuit_experiment",
+        "run_verified_circuit_experiment",
+    }
+)
+
+PROFILE_TOOL_NAMES: Mapping[str, frozenset[str]] = {
+    "core": _COMMON | _CIRCUIT_CORE | _BASIC_SIMULATION,
+    "experiment": (
+        _COMMON | _CIRCUIT_CORE | _EXPERIMENT_WORKFLOW | _ARTIFACT_WORKFLOW
+    ),
+    "optimization": (
+        _COMMON
+        | _BASIC_SIMULATION
+        | _OPTIMIZATION_WORKFLOW
+        | _SWEEP_WORKFLOW
+        | _ARTIFACT_WORKFLOW
+    ),
+    "full": ALL_TOOL_NAMES,
+}
+
+
+def normalize_tool_profile(value: str | None) -> str:
+    """Validate a profile name and preserve a stable default."""
+    profile = (value or "full").strip().lower() or "full"
+    if profile not in TOOL_PROFILES:
+        choices = ", ".join(TOOL_PROFILES)
+        raise ValueError(f"unknown tool profile {profile!r}; choose one of: {choices}")
+    return profile
+
+
+def selected_tool_profile(environment: Mapping[str, str] | None = None) -> str:
+    """Read the server profile from an explicit environment mapping."""
+    source = os.environ if environment is None else environment
+    return normalize_tool_profile(source.get(TOOL_PROFILE_ENV))
+
+
+def tool_enabled(tool_name: str, profile: str) -> bool:
+    """Return whether a named tool is discoverable in a validated profile."""
+    normalized = normalize_tool_profile(profile)
+    if normalized == "full":
+        # Future tools remain backward compatible in the default profile even
+        # before they are assigned to a smaller task-oriented profile.
+        return True
+    return tool_name in PROFILE_TOOL_NAMES[normalized]
+
+
+def tool_profile_status(profile: str) -> dict[str, object]:
+    """Return a small machine-readable description for diagnostics."""
+    normalized = normalize_tool_profile(profile)
+    names = PROFILE_TOOL_NAMES[normalized]
+    return {
+        "name": normalized,
+        "environment_variable": TOOL_PROFILE_ENV,
+        "tool_count": len(names),
+        "available_profiles": list(TOOL_PROFILES),
+    }

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -43,4 +43,8 @@ include-package-data = false
 include = ["multisim_mcp*"]
 
 [tool.setuptools.package-data]
-multisim_mcp = ["templates/*.json"]
+multisim_mcp = [
+    "templates/*.json",
+    "harness_skills/manifest.json",
+    "harness_skills/*/SKILL.md",
+]

--- a/mcp_server/tests/test_artifact_access.py
+++ b/mcp_server/tests/test_artifact_access.py
@@ -1,0 +1,198 @@
+"""COM-free tests for Tool-friendly experiment artifact access."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from multisim_mcp.experiment_resources import (
+    ARTIFACT_EXPORT_DIR_ENV,
+    clear_experiment_registry,
+    export_artifact,
+    list_artifacts,
+    read_artifact_page,
+    register_experiment,
+    summarize_experiment,
+)
+
+
+_REQUIRED = (
+    "circuit.ms14",
+    "circuit.ms14.xml",
+    "schematic.png",
+    "data.csv",
+    "result.raw",
+    "run.log",
+    "run.txt",
+    "circuit.cir",
+    "plot.svg",
+    "report.md",
+)
+
+_RAW = """Title: fixture
+Plotname: Operating Point
+Flags: real
+No. Variables: 2
+No. Points: 1
+Variables:
+0 x voltage V(in)
+1 y voltage V(out)
+Values:
+0 5
+ 2.5
+"""
+
+
+def _write_experiment(root: Path, report: str = "abcdef") -> None:
+    for filename in _REQUIRED:
+        path = root / filename
+        if filename == "report.md":
+            path.write_text(report, encoding="utf-8")
+        elif filename == "result.raw":
+            path.write_text(_RAW, encoding="utf-8")
+        else:
+            path.write_bytes((filename + " fixture\n").encode("utf-8"))
+
+
+class ArtifactAccessTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        clear_experiment_registry()
+
+    def test_listing_and_summary_are_metadata_first(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_experiment(root, report="R" * 5_000)
+            (root / "verification.json").write_text(
+                json.dumps({"overall_status": "pass"}), encoding="utf-8"
+            )
+            experiment_id = register_experiment(str(root))["experiment_id"]
+
+            listing = list_artifacts(experiment_id)
+            summary = summarize_experiment(experiment_id)
+
+        by_name = {item["name"]: item for item in listing["artifacts"]}
+        self.assertTrue(by_name["report"]["text_readable"])
+        self.assertFalse(by_name["schematic"]["text_readable"])
+        self.assertTrue(by_name["schematic"]["exportable"])
+        self.assertFalse(by_name["circuit.ms14.xml"]["exportable"])
+        self.assertEqual(summary["verification"]["result"]["overall_status"], "pass")
+        self.assertTrue(summary["measurements"]["available"])
+        self.assertEqual(summary["measurements"]["point_count"], 1)
+        self.assertEqual(summary["measurements"]["columns"][1]["mean"], 2.5)
+        self.assertEqual(len(summary["report_excerpt"]), 4_000)
+        self.assertTrue(summary["report_truncated"])
+        self.assertNotIn("content", summary["artifacts"][0])
+
+    def test_text_pagination_and_binary_rejection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_experiment(root)
+            experiment_id = register_experiment(str(root))["experiment_id"]
+            page = read_artifact_page(experiment_id, "report", offset=2, max_chars=2)
+
+            self.assertEqual(page["content"], "cd")
+            self.assertEqual(page["next_offset"], 4)
+            self.assertTrue(page["truncated"])
+            with self.assertRaisesRegex(ValueError, "text resource"):
+                read_artifact_page(experiment_id, "schematic")
+            with self.assertRaisesRegex(ValueError, "offset"):
+                read_artifact_page(experiment_id, "report", offset=-1)
+            with self.assertRaisesRegex(ValueError, "max_chars"):
+                read_artifact_page(experiment_id, "report", max_chars=100_001)
+
+    def test_summary_bounds_untrusted_verification_details(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_experiment(root)
+            requirements = [
+                {
+                    "id": f"requirement-{index}",
+                    "status": "pass",
+                    "reason": "x" * 1_000,
+                    "value": {"unexpected": "nested"},
+                }
+                for index in range(30)
+            ]
+            (root / "verification.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "overall_status": "pass",
+                        "counts": {"pass": 30, "extra": "ignored"},
+                        "requirements": requirements,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            experiment_id = register_experiment(str(root))["experiment_id"]
+            result = summarize_experiment(experiment_id)["verification"]["result"]
+
+        self.assertEqual(result["requirement_count"], 30)
+        self.assertEqual(len(result["requirements"]), 25)
+        self.assertTrue(result["requirements_truncated"])
+        self.assertEqual(len(result["requirements"][0]["reason"]), 503)
+        self.assertNotIn("value", result["requirements"][0])
+        self.assertEqual(result["counts"], {"pass": 30})
+
+    def test_export_requires_an_approved_root_and_is_atomic(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as out:
+            root = Path(tmp)
+            export_root = Path(out)
+            _write_experiment(root)
+            experiment_id = register_experiment(str(root))["experiment_id"]
+
+            with patch.dict(os.environ, {}, clear=True):
+                with self.assertRaisesRegex(RuntimeError, ARTIFACT_EXPORT_DIR_ENV):
+                    export_artifact(experiment_id, "schematic")
+
+            with patch.dict(
+                os.environ, {ARTIFACT_EXPORT_DIR_ENV: str(export_root)}, clear=False
+            ):
+                result = export_artifact(
+                    experiment_id, "schematic", destination_subdir="images"
+                )
+                destination = Path(result["destination"])
+                self.assertEqual(destination.read_bytes(), (root / "schematic.png").read_bytes())
+                self.assertEqual(
+                    result["sha256"],
+                    hashlib.sha256(destination.read_bytes()).hexdigest(),
+                )
+                self.assertFalse(list(destination.parent.glob(".*.tmp")))
+                with self.assertRaises(FileExistsError):
+                    export_artifact(
+                        experiment_id, "schematic", destination_subdir="images"
+                    )
+                replaced = export_artifact(
+                    experiment_id,
+                    "schematic",
+                    destination_subdir="images",
+                    overwrite=True,
+                )
+                self.assertTrue(replaced["success"])
+
+    def test_export_rejects_traversal_absolute_paths_and_source_collision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as out:
+            root = Path(tmp)
+            _write_experiment(root)
+            experiment_id = register_experiment(str(root))["experiment_id"]
+            with patch.dict(
+                os.environ, {ARTIFACT_EXPORT_DIR_ENV: out}, clear=False
+            ):
+                with self.assertRaisesRegex(ValueError, "escapes"):
+                    export_artifact(experiment_id, "report", "../outside")
+                with self.assertRaisesRegex(ValueError, "must be relative"):
+                    export_artifact(experiment_id, "report", str(Path(out).resolve()))
+            with patch.dict(
+                os.environ, {ARTIFACT_EXPORT_DIR_ENV: str(root)}, clear=False
+            ):
+                with self.assertRaisesRegex(ValueError, "must differ"):
+                    export_artifact(experiment_id, "report")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp_server/tests/test_cli.py
+++ b/mcp_server/tests/test_cli.py
@@ -192,6 +192,70 @@ class ConfigGeneratorTest(unittest.TestCase):
         self.assertIn("[mcp_servers.multisim-lab.env]", content)
         self.assertIn('MULTISIM_MCP_WORKDIR = "C:\\\\msre_exp"', content)
 
+    def test_deepseek_harness_cordis_yaml(self) -> None:
+        content = render_client_config(
+            "deepseek-harness",
+            server_name="multisim_lab",
+            python_executable=r"C:\Python32\python.exe",
+            template_dir=r"C:\MultisimMcp\component-pack",
+            work_dir=r"C:\msre_exp",
+            tool_profile="experiment",
+            artifact_export_dir=r"C:\MultisimMcp\exports",
+        )
+        self.assertIn('- id: "mcp-multisim_lab"', content)
+        self.assertIn('name: "@deepseek-ai/dsh-mcp-client"', content)
+        self.assertIn('serverName: "multisim_lab"', content)
+        self.assertIn('transport: "stdio"', content)
+        self.assertIn('command: "C:\\\\Python32\\\\python.exe"', content)
+        self.assertIn('- "multisim_mcp.server"', content)
+        self.assertIn("toolCallTimeoutMs: 120000", content)
+        self.assertIn("maxAttempts: 10", content)
+        self.assertIn("MULTISIM_MCP_TEMPLATE_DIR:", content)
+        self.assertIn('MULTISIM_MCP_TOOL_PROFILE: "experiment"', content)
+        self.assertIn(
+            'MULTISIM_MCP_ARTIFACT_EXPORT_DIR: "C:\\\\MultisimMcp\\\\exports"',
+            content,
+        )
+        self.assertNotIn("DEEPSEEK_API_KEY", content)
+
+    def test_deepseek_harness_enforces_upstream_server_name_rules(self) -> None:
+        with self.assertRaisesRegex(ValueError, "DeepSeek Harness server name"):
+            render_client_config("deepseek-harness", server_name="multisim.lab")
+        with self.assertRaisesRegex(ValueError, "DeepSeek Harness server name"):
+            render_client_config("deepseek-harness", server_name="m" * 33)
+
+    def test_deepseek_harness_cli_json_envelope(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            exit_code = main(
+                [
+                    "config",
+                    "--client",
+                    "deepseek-harness",
+                    "--python",
+                    r"C:\Python32\python.exe",
+                    "--tool-profile",
+                    "core",
+                    "--json",
+                ]
+            )
+        payload = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["client"], "deepseek-harness")
+        self.assertIn("@deepseek-ai/dsh-mcp-client", payload["content"])
+        self.assertIn('MULTISIM_MCP_TOOL_PROFILE: "core"', payload["content"])
+
+    def test_direct_renderer_rejects_unknown_tool_profile(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported tool profile"):
+            render_client_config("generic", tool_profile="everything")
+
+    def test_rejects_filesystem_root_as_artifact_export_dir(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not be a filesystem root"):
+            render_client_config(
+                "generic", artifact_export_dir=Path.cwd().anchor
+            )
+
     def test_generic_spec_is_not_wrapped_in_a_client_key(self) -> None:
         content = render_client_config(
             "generic", python_executable=r"C:\Python32\python.exe"
@@ -219,6 +283,26 @@ class ConfigGeneratorTest(unittest.TestCase):
         with patch("multisim_mcp.cli._run_server") as run_server:
             self.assertEqual(main([]), 0)
         run_server.assert_called_once_with()
+
+
+class HarnessSkillsCliTest(unittest.TestCase):
+    def test_harness_skills_json_installs_five_bundled_skills(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = io.StringIO()
+            with redirect_stdout(output):
+                exit_code = main(
+                    [
+                        "harness-skills",
+                        "--output",
+                        str(Path(tmp) / ".dsh" / "skills"),
+                        "--json",
+                    ]
+                )
+            payload = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["skill_count"], 5)
+        self.assertEqual(payload["command"], "harness-skills")
 
 
 if __name__ == "__main__":

--- a/mcp_server/tests/test_dsh_plugin_release.py
+++ b/mcp_server/tests/test_dsh_plugin_release.py
@@ -1,0 +1,153 @@
+"""Tests for the DeepSeek Harness npm release guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tools" / "check_dsh_plugin_release.py"
+SPEC = importlib.util.spec_from_file_location("dsh_plugin_release_check", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+release = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release)
+
+PACK_SCRIPT = REPO_ROOT / "tools" / "check_npm_pack_result.py"
+PACK_SPEC = importlib.util.spec_from_file_location("npm_pack_result_check", PACK_SCRIPT)
+assert PACK_SPEC is not None and PACK_SPEC.loader is not None
+pack_check = importlib.util.module_from_spec(PACK_SPEC)
+PACK_SPEC.loader.exec_module(pack_check)
+
+
+def existing_package(*, version: str = "0.9.0", repository: str | None = None) -> dict:
+    payload = {
+        "name": "multisim-mcp-dsh-plugin",
+        "dist-tags": {"latest": version},
+        "versions": {
+            version: {
+                "name": "multisim-mcp-dsh-plugin",
+                "version": version,
+            }
+        },
+    }
+    if repository is not None:
+        payload["repository"] = {"type": "git", "url": repository}
+    return payload
+
+
+def npm_pack_package() -> dict:
+    return {
+        "id": "multisim-mcp-dsh-plugin@1.0.0",
+        "name": "multisim-mcp-dsh-plugin",
+        "version": "1.0.0",
+        "filename": "multisim-mcp-dsh-plugin-1.0.0.tgz",
+        "size": 100,
+        "unpackedSize": 200,
+        "files": [
+            {"path": "LICENSE"},
+            {"path": "README.md"},
+            {"path": "cordis.patch.yml"},
+            {"path": "package.json"},
+        ],
+    }
+
+
+class DshPluginReleaseTest(unittest.TestCase):
+    def test_local_package_boundary_passes(self) -> None:
+        result = release.run_checks(REPO_ROOT, expected_version="1.0.0")
+        self.assertTrue(result["success"])
+        self.assertFalse(result["registry_checked"])
+        self.assertIsNone(result["registry_state"])
+
+    def test_unclaimed_name_is_valid_for_first_publication(self) -> None:
+        result = release.run_checks(
+            REPO_ROOT,
+            expected_version="1.0.0",
+            check_registry=True,
+            registry_loader=lambda name, timeout: None,
+        )
+        self.assertTrue(result["success"])
+        self.assertEqual(result["registry_state"], "unclaimed")
+
+    def test_stage_mode_requires_an_existing_package(self) -> None:
+        result = release.run_checks(
+            REPO_ROOT,
+            check_registry=True,
+            require_existing_package=True,
+            registry_loader=lambda name, timeout: None,
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["findings"][0]["check"], "registry-package")
+
+    def test_existing_package_from_same_repository_allows_new_version(self) -> None:
+        remote = existing_package(
+            repository="git+https://github.com/yxy050208/multisim-mcp.git"
+        )
+        result = release.run_checks(
+            REPO_ROOT,
+            check_registry=True,
+            require_existing_package=True,
+            registry_loader=lambda name, timeout: remote,
+        )
+        self.assertTrue(result["success"])
+        self.assertEqual(result["registry_state"], "existing")
+
+    def test_existing_target_version_is_rejected(self) -> None:
+        remote = existing_package(
+            version="1.0.0",
+            repository="https://github.com/yxy050208/multisim-mcp",
+        )
+        result = release.run_checks(
+            REPO_ROOT,
+            check_registry=True,
+            registry_loader=lambda name, timeout: remote,
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["findings"][0]["check"], "registry-version")
+
+    def test_existing_package_from_another_repository_is_rejected(self) -> None:
+        remote = existing_package(repository="https://github.com/example/squatted")
+        result = release.run_checks(
+            REPO_ROOT,
+            check_registry=True,
+            registry_loader=lambda name, timeout: remote,
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["findings"][0]["check"], "registry-ownership")
+
+    def test_requested_version_must_match_package(self) -> None:
+        result = release.run_checks(REPO_ROOT, expected_version="1.0.1")
+        self.assertFalse(result["success"])
+        self.assertEqual(result["findings"][0]["check"], "requested-version")
+
+    def test_npm_11_array_pack_output_is_supported(self) -> None:
+        result = pack_check.validate_pack_result(
+            [npm_pack_package()],
+            expected_name="multisim-mcp-dsh-plugin",
+            expected_version="1.0.0",
+        )
+        self.assertEqual(result["filename"], "multisim-mcp-dsh-plugin-1.0.0.tgz")
+
+    def test_npm_12_object_pack_output_is_supported(self) -> None:
+        result = pack_check.validate_pack_result(
+            {"multisim-mcp-dsh-plugin": npm_pack_package()},
+            expected_name="multisim-mcp-dsh-plugin",
+            expected_version="1.0.0",
+        )
+        self.assertEqual(result["files"], sorted(pack_check.EXPECTED_FILES))
+
+    def test_unexpected_npm_pack_file_is_rejected(self) -> None:
+        package = npm_pack_package()
+        package["files"].append({"path": "secret.env"})
+        with self.assertRaisesRegex(ValueError, "unexpected npm package files"):
+            pack_check.validate_pack_result(
+                {"multisim-mcp-dsh-plugin": package},
+                expected_name="multisim-mcp-dsh-plugin",
+                expected_version="1.0.0",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp_server/tests/test_harness_compatibility.py
+++ b/mcp_server/tests/test_harness_compatibility.py
@@ -1,0 +1,93 @@
+"""Tests for the version-gated DeepSeek Harness compatibility contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tools" / "check_deepseek_harness_compat.py"
+SPEC = importlib.util.spec_from_file_location("harness_compatibility_check", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+compat = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(compat)
+
+
+def matching_upstream_loader(url: str, timeout: float) -> dict:
+    if timeout <= 0:
+        raise AssertionError("timeout must be positive")
+    if url.endswith("/packages/mcp/mcp-client/package.json"):
+        return {
+            "name": "@deepseek-ai/dsh-mcp-client",
+            "version": "0.1.0-rc.7",
+            "dependencies": {"@modelcontextprotocol/sdk": "^1.12.0"},
+        }
+    if url.endswith("/apps/cli/package.json"):
+        return {"name": "@deepseek-ai/dsh", "version": "0.1.0-rc.7"}
+    return {
+        "version": "0.1.0-rc.7",
+        "packageManager": "pnpm@11.7.0",
+        "engines": {"node": "^22.19.0 || >=24.0.0"},
+    }
+
+
+class HarnessCompatibilityTest(unittest.TestCase):
+    def test_local_contract_matches_packaged_integration(self) -> None:
+        result = compat.run_checks(REPO_ROOT)
+        self.assertTrue(result["success"])
+        self.assertEqual(result["errors"], 0)
+        self.assertIsNone(result["upstream_match"])
+
+    def test_matching_upstream_metadata_passes_strict_check(self) -> None:
+        result = compat.run_checks(
+            REPO_ROOT,
+            check_upstream=True,
+            loader=matching_upstream_loader,
+        )
+        self.assertTrue(result["success"])
+        self.assertTrue(result["upstream_match"])
+        self.assertEqual(result["findings"], [])
+
+    def test_upstream_drift_can_fail_strict_or_warn_in_monitor_mode(self) -> None:
+        def drifted_loader(url: str, timeout: float) -> dict:
+            payload = matching_upstream_loader(url, timeout)
+            if url.endswith("/master/package.json"):
+                payload["version"] = "0.1.0-rc.8"
+            return payload
+
+        strict = compat.run_checks(
+            REPO_ROOT,
+            check_upstream=True,
+            loader=drifted_loader,
+        )
+        monitored = compat.run_checks(
+            REPO_ROOT,
+            check_upstream=True,
+            warn_only=True,
+            loader=drifted_loader,
+        )
+        self.assertFalse(strict["success"])
+        self.assertFalse(strict["upstream_match"])
+        self.assertEqual(strict["errors"], 1)
+        self.assertTrue(monitored["success"])
+        self.assertFalse(monitored["upstream_match"])
+        self.assertEqual(monitored["warnings"], 1)
+
+    def test_invalid_manifest_fails_before_local_imports(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_dir = root / "compatibility"
+            manifest_dir.mkdir()
+            (manifest_dir / "deepseek-harness.json").write_text(
+                '{"schema_version": 999}', encoding="utf-8"
+            )
+            result = compat.run_checks(root)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["findings"][0]["check"], "manifest")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp_server/tests/test_harness_skills.py
+++ b/mcp_server/tests/test_harness_skills.py
@@ -1,0 +1,83 @@
+"""Tests for the packaged DeepSeek Harness skill bundle."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from multisim_mcp.harness_skills import (
+    bundled_harness_skill_manifest,
+    bundled_harness_skills,
+    install_harness_skills,
+)
+
+
+EXPECTED_SKILLS = {
+    "multisim-create-experiment",
+    "multisim-debug-circuit",
+    "multisim-compare-experiments",
+    "multisim-write-lab-report",
+    "multisim-verify-requirements",
+}
+
+
+class HarnessSkillBundleTest(unittest.TestCase):
+    def test_manifest_and_frontmatter_define_exactly_five_skills(self) -> None:
+        manifest = bundled_harness_skill_manifest()
+        skills = bundled_harness_skills()
+        self.assertEqual(manifest["schema_version"], 1)
+        self.assertEqual(set(manifest["skills"]), EXPECTED_SKILLS)
+        self.assertEqual(set(skills), EXPECTED_SKILLS)
+        for name, content in skills.items():
+            with self.subTest(skill=name):
+                self.assertTrue(content.startswith("---\n"))
+                self.assertIn(f"\nname: {name}\n", content)
+                self.assertIn("description:", content)
+                self.assertIn("Multisim MCP", content)
+
+    def test_installer_refuses_overwrite_then_replaces_only_with_force(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / ".dsh" / "skills"
+            first = install_harness_skills(str(output))
+            self.assertEqual(first["skill_count"], 5)
+            self.assertEqual(set(first["skills"]), EXPECTED_SKILLS)
+            for name in EXPECTED_SKILLS:
+                self.assertTrue((output / name / "SKILL.md").is_file())
+
+            edited = output / "multisim-debug-circuit" / "SKILL.md"
+            edited.write_text("user edit\n", encoding="utf-8")
+            with self.assertRaisesRegex(FileExistsError, "--force"):
+                install_harness_skills(str(output))
+            self.assertEqual(edited.read_text(encoding="utf-8"), "user edit\n")
+
+            replaced = install_harness_skills(str(output), force=True)
+            self.assertTrue(replaced["force"])
+            self.assertIn("name: multisim-debug-circuit", edited.read_text(encoding="utf-8"))
+
+    def test_installer_rejects_empty_and_filesystem_root_outputs(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            install_harness_skills("  ")
+        with self.assertRaisesRegex(ValueError, "filesystem root"):
+            install_harness_skills(Path.cwd().anchor)
+
+    def test_preflight_rejects_invalid_skill_directory_without_partial_install(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "skills"
+            output.mkdir()
+            blocked = output / "multisim-write-lab-report"
+            blocked.write_text("not a directory", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "must be a regular directory"):
+                install_harness_skills(str(output))
+
+            self.assertEqual(
+                sorted(path.name for path in output.iterdir()),
+                ["multisim-write-lab-report"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp_server/tests/test_harness_smoke_runner.py
+++ b/mcp_server/tests/test_harness_smoke_runner.py
@@ -1,0 +1,75 @@
+"""Unit tests for the isolated official Harness smoke-test runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import signal
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, call, patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tools" / "smoke_deepseek_harness.py"
+SPEC = importlib.util.spec_from_file_location("harness_smoke_runner", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+
+
+class HarnessSmokeRunnerTest(unittest.TestCase):
+    def test_npx_command_pins_package_version(self) -> None:
+        with patch.object(smoke.shutil, "which", return_value="npx"):
+            command = smoke._npx_command("@deepseek-ai/dsh", "0.1.0-rc.7", "--version")
+        self.assertEqual(
+            command,
+            ["npx", "--yes", "@deepseek-ai/dsh@0.1.0-rc.7", "--version"],
+        )
+
+    def test_npx_command_fails_when_node_is_missing(self) -> None:
+        with patch.object(smoke.shutil, "which", return_value=None):
+            with self.assertRaisesRegex(RuntimeError, "npx is unavailable"):
+                smoke._npx_command("@deepseek-ai/dsh", "0.1.0-rc.7", "--version")
+
+    def test_process_group_options_match_platform(self) -> None:
+        options = smoke._process_group_options()
+        if smoke.os.name == "nt":
+            self.assertEqual(
+                options, {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+            )
+        else:
+            self.assertEqual(options, {"start_new_session": True})
+
+    def test_tail_is_bounded_and_utf8_tolerant(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            log = Path(temporary) / "output.log"
+            log.write_bytes(b"prefix-" + b"x" * 32 + b"-tail\xff")
+            result = smoke._tail(log, limit=12)
+        self.assertLessEqual(len(result), 12)
+        self.assertIn("tail", result)
+
+    def test_stop_process_escalates_after_timeout(self) -> None:
+        process = Mock()
+        process.poll.return_value = None
+        process.wait.side_effect = [subprocess.TimeoutExpired("dsh", 10), 0]
+        if smoke.os.name == "nt":
+            with patch.object(smoke.subprocess, "run") as taskkill:
+                smoke._stop_process(process)
+            process.send_signal.assert_called_once_with(signal.CTRL_BREAK_EVENT)
+            taskkill.assert_called_once()
+        else:
+            with patch.object(smoke.os, "killpg") as kill_group:
+                smoke._stop_process(process)
+            self.assertEqual(
+                kill_group.call_args_list,
+                [
+                    call(process.pid, signal.SIGTERM),
+                    call(process.pid, signal.SIGKILL),
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp_server/tests/test_mcp_stdio.py
+++ b/mcp_server/tests/test_mcp_stdio.py
@@ -14,16 +14,19 @@ from mcp.client.stdio import (
     get_default_environment,
     stdio_client,
 )
+from multisim_mcp.tool_profiles import PROFILE_TOOL_NAMES, TOOL_PROFILE_ENV
 
 
 class McpStdioSmokeTest(unittest.IsolatedAsyncioTestCase):
     async def _connect(
-        self, mode: str
-    ) -> tuple[str, set[str], set[str], set[str], dict]:
+        self, mode: str, tool_profile: str | None = None
+    ) -> tuple[str, set[str], set[str], set[str], dict | None]:
         package_root = Path(multisim_mcp.__file__).resolve().parent.parent
         environment = get_default_environment()
         import_paths = [str(package_root), *(item for item in sys.path if item)]
         environment["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(import_paths))
+        if tool_profile:
+            environment[TOOL_PROFILE_ENV] = tool_profile
         params = StdioServerParameters(
             command=sys.executable,
             args=["-m", "multisim_mcp.server"],
@@ -34,14 +37,19 @@ class McpStdioSmokeTest(unittest.IsolatedAsyncioTestCase):
             prompts = await session.list_prompts()
             resources = await session.list_resource_templates()
             experiment = next(
-                tool for tool in tools.tools if tool.name == "run_circuit_experiment"
+                (
+                    tool
+                    for tool in tools.tools
+                    if tool.name == "run_circuit_experiment"
+                ),
+                None,
             )
             return (
                 session.protocol_version,
                 {tool.name for tool in tools.tools},
                 {prompt.name for prompt in prompts.prompts},
                 {item.uri_template for item in resources.resource_templates},
-                experiment.output_schema,
+                experiment.output_schema if experiment else None,
             )
 
     async def test_modern_and_legacy_clients_discover_full_surface(self) -> None:
@@ -53,7 +61,7 @@ class McpStdioSmokeTest(unittest.IsolatedAsyncioTestCase):
                 mode
             )
             self.assertEqual(protocol, expected_protocol)
-            self.assertEqual(len(names), 51)
+            self.assertEqual(len(names), 55)
             self.assertEqual(len(prompts), 5)
             self.assertEqual(len(resources), 19)
 
@@ -79,6 +87,10 @@ class McpStdioSmokeTest(unittest.IsolatedAsyncioTestCase):
             self.assertIn("analyze_bode_response", names)
             self.assertIn("analyze_logic_signals", names)
             self.assertIn("export_formal_experiment_report", names)
+            self.assertIn("list_experiment_artifacts", names)
+            self.assertIn("read_experiment_artifact", names)
+            self.assertIn("export_experiment_artifact", names)
+            self.assertIn("get_experiment_summary", names)
             self.assertIn("run_spice_netlist", names)
             self.assertIn("create_circuit_experiment", prompts)
             self.assertIn("verify_design_requirements", prompts)
@@ -104,6 +116,18 @@ class McpStdioSmokeTest(unittest.IsolatedAsyncioTestCase):
                     "output_dir",
                 },
             )
+
+    async def test_task_profiles_publish_exact_stable_tool_sets(self) -> None:
+        for profile in ("core", "experiment", "optimization"):
+            with self.subTest(profile=profile):
+                _, names, prompts, resources, _ = await self._connect(
+                    "2026-07-28", tool_profile=profile
+                )
+                self.assertEqual(names, PROFILE_TOOL_NAMES[profile])
+                # Profiles reduce tool schema only; MCP Resources and Prompts
+                # retain their stable compatibility surface.
+                self.assertEqual(len(prompts), 5)
+                self.assertEqual(len(resources), 19)
 
 
 if __name__ == "__main__":

--- a/mcp_server/tests/test_tool_profiles.py
+++ b/mcp_server/tests/test_tool_profiles.py
@@ -1,0 +1,76 @@
+"""Tests for deterministic MCP tool-discovery profiles."""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+from multisim_mcp.tool_profiles import (
+    ALL_TOOL_NAMES,
+    PROFILE_TOOL_NAMES,
+    TOOL_PROFILE_ENV,
+    normalize_tool_profile,
+    selected_tool_profile,
+    tool_enabled,
+    tool_profile_status,
+)
+
+
+class ToolProfileTest(unittest.TestCase):
+    def test_catalog_matches_every_decorated_server_tool(self) -> None:
+        server_path = Path(__file__).parents[1] / "multisim_mcp" / "server.py"
+        tree = ast.parse(server_path.read_text(encoding="utf-8"))
+        decorated = {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and any(
+                isinstance(decorator, ast.Call)
+                and isinstance(decorator.func, ast.Attribute)
+                and isinstance(decorator.func.value, ast.Name)
+                and decorator.func.value.id == "mcp"
+                and decorator.func.attr == "tool"
+                for decorator in node.decorator_list
+            )
+        }
+        self.assertEqual(decorated, ALL_TOOL_NAMES)
+        self.assertEqual(len(ALL_TOOL_NAMES), 55)
+
+    def test_profiles_are_bounded_and_keep_runtime_diagnostics(self) -> None:
+        for name, tools in PROFILE_TOOL_NAMES.items():
+            with self.subTest(profile=name):
+                self.assertTrue(tools <= ALL_TOOL_NAMES)
+                self.assertIn("runtime_status", tools)
+        self.assertLess(len(PROFILE_TOOL_NAMES["core"]), len(ALL_TOOL_NAMES))
+        self.assertLess(len(PROFILE_TOOL_NAMES["experiment"]), len(ALL_TOOL_NAMES))
+        self.assertLess(
+            len(PROFILE_TOOL_NAMES["optimization"]), len(ALL_TOOL_NAMES)
+        )
+
+    def test_default_is_full_and_environment_is_explicit(self) -> None:
+        self.assertEqual(selected_tool_profile({}), "full")
+        self.assertEqual(
+            selected_tool_profile({TOOL_PROFILE_ENV: " EXPERIMENT "}),
+            "experiment",
+        )
+
+    def test_invalid_profile_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unknown tool profile"):
+            normalize_tool_profile("everything")
+
+    def test_full_keeps_future_tools_but_bounded_profiles_do_not(self) -> None:
+        self.assertTrue(tool_enabled("future_tool", "full"))
+        self.assertFalse(tool_enabled("future_tool", "core"))
+
+    def test_status_is_machine_readable(self) -> None:
+        status = tool_profile_status("optimization")
+        self.assertEqual(status["name"], "optimization")
+        self.assertEqual(
+            status["tool_count"], len(PROFILE_TOOL_NAMES["optimization"])
+        )
+        self.assertIn("full", status["available_profiles"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/README.md
+++ b/skills/README.md
@@ -3,3 +3,13 @@
 - `multisim-workflow/SKILL.md`: end-to-end agent workflow for Multisim circuit generation, simulation, data capture, and reporting.
 
 The skill assumes the `multisim` MCP server from `../mcp_server` is registered in the client.
+
+DeepSeek Harness users should install the five packaged, task-specific skills
+from their project root instead:
+
+```powershell
+multisim-mcp harness-skills --output .dsh/skills
+```
+
+The installer refuses to replace existing project skills unless `--force` is
+explicit. See [`docs/DEEPSEEK_HARNESS.md`](../docs/DEEPSEEK_HARNESS.md).

--- a/tools/check_deepseek_harness_compat.py
+++ b/tools/check_deepseek_harness_compat.py
@@ -1,0 +1,391 @@
+"""Validate the pinned DeepSeek Harness integration contract.
+
+Local checks are deterministic and suitable for every pull request. Upstream
+checks are opt-in because DeepSeek Harness is still a Developer Preview and may
+change independently of this repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+
+SCHEMA_VERSION = 1
+DEFAULT_TIMEOUT_SECONDS = 20.0
+JsonLoader = Callable[[str, float], dict[str, Any]]
+
+
+def _load_json_url(url: str, timeout: float) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "multisim-mcp-harness-compatibility-check/1"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _finding(level: str, check: str, message: str) -> dict[str, str]:
+    return {"level": level, "check": check, "message": message}
+
+
+def load_compatibility_manifest(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unsupported DeepSeek Harness compatibility schema")
+    if payload.get("status") != "developer-preview":
+        raise ValueError("Harness status must explicitly remain developer-preview")
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", str(payload.get("verified_date", ""))):
+        raise ValueError("verified_date must use YYYY-MM-DD")
+    upstream = payload.get("upstream")
+    if not isinstance(upstream, dict):
+        raise ValueError("compatibility manifest is missing upstream metadata")
+    required_upstream = (
+        "repository",
+        "root_package_url",
+        "dsh_cli_package_url",
+        "mcp_client_package_url",
+        "harness_version",
+        "dsh_cli_package",
+        "dsh_cli_version",
+        "mcp_client_package",
+        "mcp_client_version",
+        "node_engine",
+        "package_manager",
+        "mcp_sdk_range",
+    )
+    missing_upstream = [key for key in required_upstream if not upstream.get(key)]
+    if missing_upstream:
+        raise ValueError(f"upstream metadata is missing: {', '.join(missing_upstream)}")
+    official_raw_prefix = "https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/"
+    for key in (
+        "root_package_url",
+        "dsh_cli_package_url",
+        "mcp_client_package_url",
+    ):
+        if not str(upstream[key]).startswith(official_raw_prefix):
+            raise ValueError(f"{key} must reference the official DeepSeek repository")
+
+    contract = payload.get("contract")
+    if not isinstance(contract, dict):
+        raise ValueError("compatibility manifest is missing the local contract")
+    if contract.get("transport") != "stdio":
+        raise ValueError("the verified Harness transport must be stdio")
+    if contract.get("mcp_resources_bridged") is not False:
+        raise ValueError("MCP Resources must remain explicitly marked unbridged")
+    if contract.get("mcp_prompts_bridged") is not False:
+        raise ValueError("MCP Prompts must remain explicitly marked unbridged")
+    for key in (
+        "tool_name_prefix",
+        "skill_discovery_root",
+        "bundle_package",
+        "bundle_version",
+        "bundle_path",
+    ):
+        if not isinstance(contract.get(key), str) or not contract[key]:
+            raise ValueError(f"contract is missing {key}")
+    try:
+        re.compile(contract["server_name_pattern"])
+    except (KeyError, re.error) as exc:
+        raise ValueError("invalid or missing server_name_pattern") from exc
+    profiles = contract.get("tool_profiles")
+    if not isinstance(profiles, dict) or not profiles:
+        raise ValueError("contract must contain tool profile counts")
+    if any(not isinstance(value, int) or value <= 0 for value in profiles.values()):
+        raise ValueError("tool profile counts must be positive integers")
+    skills = contract.get("skills")
+    if (
+        not isinstance(skills, list)
+        or not skills
+        or any(not isinstance(name, str) or not name for name in skills)
+        or len(skills) != len(set(skills))
+    ):
+        raise ValueError("contract skills must be a non-empty unique list")
+    return payload
+
+
+def check_local_contract(repo_root: Path, manifest: dict[str, Any]) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    package_root = repo_root / "mcp_server"
+    sys.path.insert(0, str(package_root))
+    try:
+        from multisim_mcp.harness_skills import bundled_harness_skill_manifest
+        from multisim_mcp.tool_profiles import PROFILE_TOOL_NAMES
+    except Exception as exc:  # pragma: no cover - defensive environment boundary
+        return [_finding("error", "local-import", f"cannot import local package: {exc}")]
+    finally:
+        if sys.path and sys.path[0] == str(package_root):
+            sys.path.pop(0)
+
+    contract = manifest["contract"]
+    expected_profiles = contract.get("tool_profiles", {})
+    actual_profiles = {name: len(names) for name, names in PROFILE_TOOL_NAMES.items()}
+    if actual_profiles != expected_profiles:
+        findings.append(
+            _finding(
+                "error",
+                "tool-profiles",
+                f"expected {expected_profiles}, found {actual_profiles}",
+            )
+        )
+
+    skill_manifest = bundled_harness_skill_manifest()
+    expected_skills = contract.get("skills", [])
+    if skill_manifest.get("skills") != expected_skills:
+        findings.append(
+            _finding(
+                "error",
+                "harness-skills",
+                "packaged Harness skill names or order differ from the contract",
+            )
+        )
+    discovery_root = skill_manifest.get("upstream", {}).get("discovery_root")
+    if discovery_root != contract.get("skill_discovery_root"):
+        findings.append(
+            _finding(
+                "error",
+                "skill-discovery-root",
+                f"expected {contract.get('skill_discovery_root')!r}, found {discovery_root!r}",
+            )
+        )
+
+    bundle_root = repo_root / contract["bundle_path"]
+    bundle_manifest_path = bundle_root / "package.json"
+    bundle_patch_path = bundle_root / "cordis.patch.yml"
+    bundle_license_path = bundle_root / "LICENSE"
+    try:
+        bundle_manifest = json.loads(bundle_manifest_path.read_text(encoding="utf-8"))
+        bundle_patch = bundle_patch_path.read_text(encoding="utf-8")
+    except (OSError, json.JSONDecodeError) as exc:
+        findings.append(
+            _finding("error", "bundle-package", f"cannot read Harness bundle: {exc}")
+        )
+    else:
+        bundle_comparisons = {
+            "name": (contract["bundle_package"], bundle_manifest.get("name")),
+            "version": (contract["bundle_version"], bundle_manifest.get("version")),
+            "mcp-client": (
+                manifest["upstream"]["mcp_client_version"],
+                bundle_manifest.get("dependencies", {}).get(
+                    manifest["upstream"]["mcp_client_package"]
+                ),
+            ),
+            "patch": (
+                "./cordis.patch.yml",
+                bundle_manifest.get("dsh", {}).get("bundle", {}).get("patch"),
+            ),
+        }
+        for field, (wanted, actual) in bundle_comparisons.items():
+            if wanted != actual:
+                findings.append(
+                    _finding(
+                        "error",
+                        "bundle-package",
+                        f"{field} expected {wanted!r}, found {actual!r}",
+                    )
+                )
+        pyproject = (package_root / "pyproject.toml").read_text(encoding="utf-8")
+        version_match = re.search(
+            r'(?m)^version\s*=\s*"([^"]+)"\s*$', pyproject
+        )
+        python_version = version_match.group(1) if version_match else None
+        if bundle_manifest.get("version") != python_version:
+            findings.append(
+                _finding(
+                    "error",
+                    "bundle-version-sync",
+                    "Harness bundle and Python package versions must match",
+                )
+            )
+        required_patch_fragments = (
+            'name: "@deepseek-ai/dsh-mcp-client"',
+            'serverName: "multisim"',
+            'transport: "stdio"',
+            "MULTISIM_MCP_PYTHON",
+            "failOnStartupError: true",
+        )
+        for fragment in required_patch_fragments:
+            if fragment not in bundle_patch:
+                findings.append(
+                    _finding(
+                        "error", "bundle-patch", f"missing fragment: {fragment}"
+                    )
+                )
+        if "DEEPSEEK_API_KEY" in bundle_patch:
+            findings.append(
+                _finding(
+                    "error",
+                    "bundle-credential-boundary",
+                    "bundle must not forward DEEPSEEK_API_KEY to the MCP child",
+                )
+            )
+        if not bundle_license_path.is_file():
+            findings.append(
+                _finding("error", "bundle-license", "Harness bundle is missing LICENSE")
+            )
+
+    source = (package_root / "multisim_mcp" / "cli.py").read_text(encoding="utf-8")
+    expected_package = manifest["upstream"].get("mcp_client_package")
+    required_fragments = (
+        f'name: "{expected_package}"',
+        f'transport: "{contract.get("transport")}"',
+        "serverName:",
+        "TOOL_PROFILE_ENV",
+    )
+    for fragment in required_fragments:
+        if fragment not in source:
+            findings.append(
+                _finding("error", "cordis-config", f"missing fragment: {fragment}")
+            )
+
+    pattern = contract.get("server_name_pattern")
+    if pattern not in source:
+        findings.append(
+            _finding(
+                "error",
+                "server-name-pattern",
+                "CLI server-name validation differs from the pinned contract",
+            )
+        )
+    return findings
+
+
+def check_upstream_contract(
+    manifest: dict[str, Any],
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    loader: JsonLoader = _load_json_url,
+) -> list[dict[str, str]]:
+    expected = manifest["upstream"]
+    try:
+        root = loader(expected["root_package_url"], timeout)
+        cli = loader(expected["dsh_cli_package_url"], timeout)
+        client = loader(expected["mcp_client_package_url"], timeout)
+    except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError) as exc:
+        return [_finding("drift", "upstream-fetch", f"cannot read upstream metadata: {exc}")]
+
+    comparisons = {
+        "harness-version": (expected["harness_version"], root.get("version")),
+        "dsh-cli-package": (expected["dsh_cli_package"], cli.get("name")),
+        "dsh-cli-version": (expected["dsh_cli_version"], cli.get("version")),
+        "node-engine": (expected["node_engine"], root.get("engines", {}).get("node")),
+        "package-manager": (expected["package_manager"], root.get("packageManager")),
+        "mcp-client-package": (expected["mcp_client_package"], client.get("name")),
+        "mcp-client-version": (expected["mcp_client_version"], client.get("version")),
+        "mcp-sdk-range": (
+            expected["mcp_sdk_range"],
+            client.get("dependencies", {}).get("@modelcontextprotocol/sdk"),
+        ),
+    }
+    findings = []
+    for check, (wanted, actual) in comparisons.items():
+        if wanted != actual:
+            findings.append(
+                _finding("drift", check, f"expected {wanted!r}, upstream has {actual!r}")
+            )
+    return findings
+
+
+def run_checks(
+    repo_root: Path,
+    *,
+    check_upstream: bool = False,
+    warn_only: bool = False,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    loader: JsonLoader = _load_json_url,
+) -> dict[str, Any]:
+    manifest_path = repo_root / "compatibility" / "deepseek-harness.json"
+    try:
+        manifest = load_compatibility_manifest(manifest_path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        findings = [_finding("error", "manifest", str(exc))]
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "success": False,
+            "upstream_checked": False,
+            "upstream_match": None,
+            "findings": findings,
+        }
+
+    findings = check_local_contract(repo_root, manifest)
+    upstream_findings: list[dict[str, str]] = []
+    if check_upstream:
+        upstream_findings = check_upstream_contract(
+            manifest, timeout=timeout, loader=loader
+        )
+        for finding in upstream_findings:
+            finding["level"] = "warning" if warn_only else "error"
+        findings.extend(upstream_findings)
+
+    errors = sum(item["level"] == "error" for item in findings)
+    warnings = sum(item["level"] == "warning" for item in findings)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "success": errors == 0,
+        "verified_date": manifest["verified_date"],
+        "pinned_harness_version": manifest["upstream"]["harness_version"],
+        "upstream_checked": check_upstream,
+        "upstream_match": not upstream_findings if check_upstream else None,
+        "errors": errors,
+        "warnings": warnings,
+        "findings": findings,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate the pinned DeepSeek Harness integration contract"
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repository root (default: inferred from this script)",
+    )
+    parser.add_argument(
+        "--check-upstream",
+        action="store_true",
+        help="compare the pinned versions with the official upstream package files",
+    )
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="report upstream drift as warnings; local contract errors still fail",
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.warn_only and not args.check_upstream:
+        raise SystemExit("--warn-only requires --check-upstream")
+    if args.timeout <= 0:
+        raise SystemExit("--timeout must be positive")
+    result = run_checks(
+        args.repo_root.resolve(),
+        check_upstream=args.check_upstream,
+        warn_only=args.warn_only,
+        timeout=args.timeout,
+    )
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        state = "PASS" if result["success"] else "FAIL"
+        print(f"DeepSeek Harness compatibility: {state}")
+        for finding in result["findings"]:
+            print(f"[{finding['level']}] {finding['check']}: {finding['message']}")
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_dsh_plugin_release.py
+++ b/tools/check_dsh_plugin_release.py
@@ -1,0 +1,264 @@
+"""Preflight the independently published DeepSeek Harness npm bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+
+TOOLS_ROOT = Path(__file__).resolve().parent
+if str(TOOLS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TOOLS_ROOT))
+
+import check_deepseek_harness_compat as compatibility  # noqa: E402
+
+
+DEFAULT_TIMEOUT_SECONDS = 20.0
+EXPECTED_PACKAGE_FILES = {
+    "LICENSE",
+    "README.md",
+    "cordis.patch.yml",
+    "package.json",
+}
+RegistryLoader = Callable[[str, float], dict[str, Any] | None]
+
+
+def _finding(check: str, message: str) -> dict[str, str]:
+    return {"level": "error", "check": check, "message": message}
+
+
+def _load_registry_package(name: str, timeout: float) -> dict[str, Any] | None:
+    encoded_name = urllib.parse.quote(name, safe="")
+    request = urllib.request.Request(
+        f"https://registry.npmjs.org/{encoded_name}",
+        headers={"User-Agent": "multisim-mcp-dsh-release-check/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def _repository_url(value: Any) -> str | None:
+    if isinstance(value, dict):
+        value = value.get("url")
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().lower()
+    if normalized.startswith("git+"):
+        normalized = normalized[4:]
+    if normalized.startswith("git@github.com:"):
+        normalized = "https://github.com/" + normalized.split(":", 1)[1]
+    if normalized.startswith("git://github.com/"):
+        normalized = "https://github.com/" + normalized.removeprefix(
+            "git://github.com/"
+        )
+    return normalized.removesuffix("/").removesuffix(".git")
+
+
+def _registry_repository(payload: dict[str, Any]) -> str | None:
+    direct = _repository_url(payload.get("repository"))
+    if direct:
+        return direct
+    latest = payload.get("dist-tags", {}).get("latest")
+    if isinstance(latest, str):
+        version = payload.get("versions", {}).get(latest, {})
+        return _repository_url(version.get("repository"))
+    return None
+
+
+def _check_package_boundary(
+    repo_root: Path,
+    package: dict[str, Any],
+    contract: dict[str, Any],
+    expected_version: str | None,
+) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    package_root = repo_root / contract["bundle_path"]
+    comparisons = {
+        "package-name": (contract["bundle_package"], package.get("name")),
+        "package-version": (contract["bundle_version"], package.get("version")),
+        "package-license": ("MIT", package.get("license")),
+        "package-access": ("public", package.get("publishConfig", {}).get("access")),
+    }
+    if expected_version is not None:
+        comparisons["requested-version"] = (expected_version, package.get("version"))
+    for check, (wanted, actual) in comparisons.items():
+        if wanted != actual:
+            findings.append(
+                _finding(check, f"expected {wanted!r}, found {actual!r}")
+            )
+
+    if package.get("private") is True:
+        findings.append(_finding("package-private", "publishable bundle cannot be private"))
+
+    declared = package.get("files")
+    if not isinstance(declared, list) or any(
+        not isinstance(item, str) for item in declared
+    ):
+        findings.append(_finding("package-files", "files must be a string array"))
+        declared_files: set[str] = set()
+    else:
+        declared_files = set(declared) | {"package.json"}
+        if declared_files != EXPECTED_PACKAGE_FILES:
+            findings.append(
+                _finding(
+                    "package-files",
+                    f"expected {sorted(EXPECTED_PACKAGE_FILES)}, found {sorted(declared_files)}",
+                )
+            )
+
+    for relative in declared_files:
+        path = package_root / relative
+        if path.is_symlink():
+            findings.append(
+                _finding("package-files", f"symbolic links are not publishable: {relative}")
+            )
+        elif not path.is_file():
+            findings.append(_finding("package-files", f"missing file: {relative}"))
+
+    repository = _repository_url(package.get("repository"))
+    if repository != "https://github.com/yxy050208/multisim-mcp":
+        findings.append(
+            _finding(
+                "package-repository",
+                "package repository must be https://github.com/yxy050208/multisim-mcp",
+            )
+        )
+    return findings
+
+
+def run_checks(
+    repo_root: Path,
+    *,
+    expected_version: str | None = None,
+    check_registry: bool = False,
+    require_existing_package: bool = False,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    registry_loader: RegistryLoader = _load_registry_package,
+) -> dict[str, Any]:
+    compatibility_result = compatibility.run_checks(repo_root)
+    findings = list(compatibility_result["findings"])
+    registry_state: str | None = None
+
+    manifest_path = repo_root / "compatibility" / "deepseek-harness.json"
+    try:
+        manifest = compatibility.load_compatibility_manifest(manifest_path)
+        contract = manifest["contract"]
+        package_path = repo_root / contract["bundle_path"] / "package.json"
+        package = json.loads(package_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError, KeyError) as exc:
+        findings.append(_finding("release-metadata", str(exc)))
+        package = {}
+        contract = {}
+    else:
+        findings.extend(
+            _check_package_boundary(repo_root, package, contract, expected_version)
+        )
+
+    if require_existing_package and not check_registry:
+        findings.append(
+            _finding(
+                "registry-mode",
+                "require_existing_package requires check_registry",
+            )
+        )
+
+    if check_registry and package.get("name") and package.get("version"):
+        try:
+            registry_package = registry_loader(package["name"], timeout)
+        except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError) as exc:
+            findings.append(_finding("registry-fetch", f"cannot query npm registry: {exc}"))
+            registry_state = "unavailable"
+        else:
+            if registry_package is None:
+                registry_state = "unclaimed"
+                if require_existing_package:
+                    findings.append(
+                        _finding(
+                            "registry-package",
+                            "staged publishing requires an existing npm package",
+                        )
+                    )
+            else:
+                registry_state = "existing"
+                versions = registry_package.get("versions", {})
+                if package["version"] in versions:
+                    findings.append(
+                        _finding(
+                            "registry-version",
+                            f"{package['name']}@{package['version']} already exists",
+                        )
+                    )
+                local_repository = _repository_url(package.get("repository"))
+                remote_repository = _registry_repository(registry_package)
+                if remote_repository != local_repository:
+                    findings.append(
+                        _finding(
+                            "registry-ownership",
+                            "existing package repository does not match this project",
+                        )
+                    )
+
+    errors = sum(item.get("level") == "error" for item in findings)
+    return {
+        "schema_version": 1,
+        "success": errors == 0,
+        "package": package.get("name"),
+        "version": package.get("version"),
+        "registry_checked": check_registry,
+        "registry_state": registry_state,
+        "errors": errors,
+        "findings": findings,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate the DeepSeek Harness npm bundle before release"
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+    )
+    parser.add_argument("--expected-version")
+    parser.add_argument("--check-registry", action="store_true")
+    parser.add_argument("--require-existing-package", action="store_true")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.timeout <= 0:
+        raise SystemExit("--timeout must be positive")
+    result = run_checks(
+        args.repo_root.resolve(),
+        expected_version=args.expected_version,
+        check_registry=args.check_registry,
+        require_existing_package=args.require_existing_package,
+        timeout=args.timeout,
+    )
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        state = "PASS" if result["success"] else "FAIL"
+        print(f"DeepSeek Harness plugin release: {state}")
+        for finding in result["findings"]:
+            print(f"[{finding['level']}] {finding['check']}: {finding['message']}")
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_npm_pack_result.py
+++ b/tools/check_npm_pack_result.py
@@ -1,0 +1,88 @@
+"""Validate npm 11/12 ``npm pack --json`` output for the Harness bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_FILES = ["LICENSE", "README.md", "cordis.patch.yml", "package.json"]
+
+
+def validate_pack_result(
+    payload: Any,
+    *,
+    expected_name: str,
+    expected_version: str,
+) -> dict[str, Any]:
+    if isinstance(payload, list):
+        packages = payload
+    elif isinstance(payload, dict):
+        packages = list(payload.values())
+    else:
+        raise ValueError("npm pack JSON must be an array or object")
+    if len(packages) != 1 or not isinstance(packages[0], dict):
+        raise ValueError("npm pack must return exactly one package")
+
+    package = packages[0]
+    if package.get("name") != expected_name:
+        raise ValueError(
+            f"expected package {expected_name!r}, found {package.get('name')!r}"
+        )
+    if package.get("version") != expected_version:
+        raise ValueError(
+            f"expected version {expected_version!r}, found {package.get('version')!r}"
+        )
+    files = package.get("files")
+    if not isinstance(files, list) or any(not isinstance(item, dict) for item in files):
+        raise ValueError("npm pack files must be an array of objects")
+    raw_paths = [item.get("path") for item in files]
+    if any(not isinstance(path, str) for path in raw_paths):
+        raise ValueError("every npm pack file must have a string path")
+    paths = sorted(raw_paths)
+    if paths != sorted(EXPECTED_FILES):
+        raise ValueError(f"unexpected npm package files: {paths!r}")
+    filename = package.get("filename")
+    if not isinstance(filename, str) or not filename.endswith(".tgz"):
+        raise ValueError("npm pack did not report a tarball filename")
+    return {
+        "id": package.get("id"),
+        "name": package["name"],
+        "version": package["version"],
+        "filename": filename,
+        "size": package.get("size"),
+        "unpacked_size": package.get("unpackedSize"),
+        "files": paths,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate npm pack JSON output")
+    parser.add_argument("path", type=Path)
+    parser.add_argument(
+        "--expected-name", default="multisim-mcp-dsh-plugin"
+    )
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--filename-only", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = json.loads(args.path.read_text(encoding="utf-8"))
+    result = validate_pack_result(
+        payload,
+        expected_name=args.expected_name,
+        expected_version=args.expected_version,
+    )
+    if args.filename_only:
+        print(result["filename"])
+    else:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/smoke_deepseek_harness.py
+++ b/tools/smoke_deepseek_harness.py
@@ -1,0 +1,311 @@
+"""Run an isolated end-to-end smoke test with the official DeepSeek Harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+
+
+def _free_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _tail(path: Path, limit: int = 8000) -> str:
+    if not path.exists():
+        return ""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return text[-limit:]
+
+
+def _npx_command(package: str, version: str, *args: str) -> list[str]:
+    executable = shutil.which("npx")
+    if not executable:
+        raise RuntimeError("npx is unavailable; install Node.js 22.19+ or 24+")
+    return [executable, "--yes", f"{package}@{version}", *args]
+
+
+def _process_group_options() -> dict[str, Any]:
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def _wait_for_web(
+    process: subprocess.Popen[Any], port: int, timeout: float
+) -> tuple[bool, str]:
+    deadline = time.monotonic() + timeout
+    url = f"http://127.0.0.1:{port}/"
+    last_error = "web endpoint did not respond"
+    while time.monotonic() < deadline:
+        return_code = process.poll()
+        if return_code is not None:
+            return False, f"dsh exited before readiness with code {return_code}"
+        try:
+            with urllib.request.urlopen(url, timeout=2) as response:
+                if 200 <= response.status < 500:
+                    return True, f"HTTP {response.status}"
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = str(exc)
+        time.sleep(0.5)
+    return False, last_error
+
+
+def _stop_process(process: subprocess.Popen[Any]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        try:
+            process.send_signal(signal.CTRL_BREAK_EVENT)
+        except OSError:
+            process.terminate()
+    else:
+        os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        if os.name == "nt":
+            subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+                check=False,
+            )
+        else:
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=5)
+
+
+def _run_bounded(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **_process_group_options(),
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _stop_process(process)
+        process.communicate()
+        raise
+    return subprocess.CompletedProcess(
+        command,
+        process.returncode,
+        stdout,
+        stderr,
+    )
+
+
+def run_smoke(
+    repo_root: Path,
+    *,
+    install_timeout: float = 300,
+    startup_timeout: float = 120,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    compatibility = json.loads(
+        (repo_root / "compatibility" / "deepseek-harness.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    upstream = compatibility["upstream"]
+    contract = compatibility["contract"]
+    package = upstream["dsh_cli_package"]
+    version = upstream["dsh_cli_version"]
+    patch = repo_root / contract["bundle_path"] / "cordis.patch.yml"
+    if not patch.is_file():
+        raise RuntimeError(f"Harness bundle patch is missing: {patch}")
+
+    with tempfile.TemporaryDirectory(prefix="multisim-mcp-dsh-smoke-") as temporary:
+        temp_root = Path(temporary)
+        home = temp_root / "dsh-home"
+        workspace = temp_root / "workspace"
+        home.mkdir()
+        workspace.mkdir()
+        stdout_path = temp_root / "dsh.stdout.log"
+        stderr_path = temp_root / "dsh.stderr.log"
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "DSH_HOME": str(home),
+                "DSH_TELEMETRY_DISABLED": "1",
+                "MULTISIM_MCP_PYTHON": sys.executable,
+                "MULTISIM_MCP_TOOL_PROFILE": "experiment",
+                "PYTHONUTF8": "1",
+            }
+        )
+        environment.pop("DEEPSEEK_API_KEY", None)
+
+        version_check = _run_bounded(
+            _npx_command(package, version, "--version"),
+            cwd=workspace,
+            env=environment,
+            timeout=install_timeout,
+        )
+        if version_check.returncode != 0:
+            raise RuntimeError(
+                "official dsh version check failed: "
+                + (version_check.stderr or version_check.stdout)[-4000:]
+            )
+        reported_version = version_check.stdout.strip()
+        if version not in reported_version:
+            raise RuntimeError(
+                f"expected dsh {version}, version command returned {reported_version!r}"
+            )
+
+        dump = _run_bounded(
+            _npx_command(
+                package,
+                version,
+                "web",
+                "--patch",
+                str(patch),
+                "--dump-config",
+            ),
+            cwd=workspace,
+            env=environment,
+            timeout=install_timeout,
+        )
+        if dump.returncode != 0:
+            raise RuntimeError(
+                "dsh rejected the Multisim Cordis patch: "
+                + (dump.stderr or dump.stdout)[-4000:]
+            )
+        for fragment in ("mcp-multisim", "@deepseek-ai/dsh-mcp-client"):
+            if fragment not in dump.stdout:
+                raise RuntimeError(f"composed dsh config is missing {fragment!r}")
+
+        port = _free_loopback_port()
+        command = _npx_command(
+            package,
+            version,
+            "web",
+            "--patch",
+            str(patch),
+            "--port",
+            str(port),
+        )
+        with stdout_path.open("w", encoding="utf-8") as stdout_handle, stderr_path.open(
+            "w", encoding="utf-8"
+        ) as stderr_handle:
+            process = subprocess.Popen(
+                command,
+                cwd=workspace,
+                env=environment,
+                text=True,
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+                **_process_group_options(),
+            )
+            try:
+                web_ready, readiness = _wait_for_web(
+                    process, port, startup_timeout
+                )
+            finally:
+                _stop_process(process)
+
+        stdout_tail = _tail(stdout_path)
+        stderr_tail = _tail(stderr_path)
+        if not web_ready:
+            raise RuntimeError(
+                f"official dsh web smoke failed: {readiness}\n"
+                f"stdout tail:\n{stdout_tail}\n"
+                f"stderr tail:\n{stderr_tail}"
+            )
+        failure_markers = (
+            "initial connection failed",
+            "failed to list tools",
+            "plugin activation failed",
+        )
+        combined = f"{stdout_tail}\n{stderr_tail}".lower()
+        found_failures = [marker for marker in failure_markers if marker in combined]
+        if found_failures:
+            raise RuntimeError(
+                "dsh became ready but reported MCP activation failure: "
+                + ", ".join(found_failures)
+            )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "success": True,
+        "dsh_package": package,
+        "dsh_version": version,
+        "reported_version": reported_version,
+        "config_dump": True,
+        "mcp_fail_on_startup_error": True,
+        "web_ready": True,
+        "readiness": readiness,
+        "api_key_forwarded": False,
+        "elapsed_seconds": round(time.monotonic() - started, 3),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Smoke-test Multisim MCP with the pinned official dsh CLI"
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+    )
+    parser.add_argument("--install-timeout", type=float, default=300)
+    parser.add_argument("--startup-timeout", type=float, default=120)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.install_timeout <= 0 or args.startup_timeout <= 0:
+        raise SystemExit("timeouts must be positive")
+    try:
+        result = run_smoke(
+            args.repo_root.resolve(),
+            install_timeout=args.install_timeout,
+            startup_timeout=args.startup_timeout,
+        )
+    except (OSError, RuntimeError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        result = {
+            "schema_version": SCHEMA_VERSION,
+            "success": False,
+            "error": {"type": type(exc).__name__, "message": str(exc)[-12000:]},
+        }
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print("DeepSeek Harness smoke: " + ("PASS" if result["success"] else "FAIL"))
+        if not result["success"]:
+            print(result["error"]["message"])
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

本 PR 增加 Multisim MCP 对 DeepSeek Harness 的完整开发者预览适配，并为后续独立 npm bundle 发布建立可审计门禁。

- 增加 DeepSeek Harness Cordis 配置生成、服务端 Tool Profile 和 5 个工程工作流 Skills。
- 增加有界实验产物读取、导出和摘要接口，补足 Harness 当前不消费 MCP Resources/Prompts 的能力缺口。
- 增加独立 `multisim-mcp-dsh-plugin` bundle、固定上游兼容性清单和真实 Harness smoke runner。
- 增加 npm Registry 归属/重复版本守卫、npm 11/12 打包结果验证，以及 OIDC 暂存发布工作流。
- 补充中文为主的 DeepSeek/Harness 使用、发布和 2.0 路线图文档。

## 原因与影响

目标是让 DeepSeek Harness 能可靠调用 Multisim MCP 完成电路创建、实验、诊断、优化和报告工作流，同时保持现有 MCP 客户端兼容性。默认 `full` Profile 仍暴露完整工具集；用户可选择 `core`、`experiment` 或 `optimization` 以减少模型上下文占用。

本 PR 不发布 npm/PyPI 包，也不改变 Multisim 授权或 32 位运行时要求。独立 npm 包当前仍未发布。

## 安全与发布边界

- `DEEPSEEK_API_KEY` 只属于 Harness，不转发给 MCP 子进程。
- 二进制实验产物不以内联 base64 进入模型上下文；导出仅允许写入明确批准的根目录。
- npm tarball 限定为 4 个审查文件。
- 首次 npm 发布要求维护者本地 2FA；包创建后只允许 GitHub OIDC 暂存，再由维护者 2FA 审批。
- CI 和 release audit 继续拒绝 NI XML、设计文件、本地实验输出和开发环境文件。

## 验证

- 本地：157 项测试通过，19 项真实 Multisim/COM 条件测试按设计跳过。
- wheel/sdist 构建及公开边界检查通过，无 NI XML，包含 5 个 Harness Skills。
- npm 11 与 npm 12 dry-run 均验证为严格 4 文件 bundle。
- Registry 发布守卫通过；检查时包名状态为 `unclaimed`。
- Release audit：0 errors。
- GitHub Actions：Windows、Windows x86、Linux Docker introspection 全部通过。
  - https://github.com/yxy050208/multisim-mcp/actions/runs/32156698764

## English summary

Adds a version-gated DeepSeek Harness integration, bounded artifact access, tool profiles, five packaged engineering skills, an independently installable Harness bundle, and guarded npm release automation. Credentials remain in Harness, package boundaries are audited, and all public CI jobs pass.