### PR TITLE
fix: 修复 Windows 共享作业状态写入竞态

### DIFF
--- a/mcp_server/multisim_mcp/job_engine.py
+++ b/mcp_server/multisim_mcp/job_engine.py
@@ -76,7 +76,24 @@ def _atomic_json(path: Path, value: object) -> None:
             os.chmod(temporary, 0o600)
         except OSError:
             pass
-        os.replace(temporary, path)
+        # A second manager may briefly have the destination open while it
+        # refreshes the shared queue.  Windows then reports access denied or a
+        # sharing violation even though the atomic replace is otherwise valid.
+        # Retry only those transient errors and keep the delay bounded so real
+        # permission failures are still surfaced promptly.
+        delay = 0.005
+        for attempt in range(8):
+            try:
+                os.replace(temporary, path)
+                break
+            except OSError as exc:
+                transient = isinstance(exc, PermissionError) or getattr(
+                    exc, "winerror", None
+                ) in {5, 32, 33}
+                if not transient or attempt == 7:
+                    raise
+                time.sleep(delay)
+                delay = min(delay * 2, 0.08)
     finally:
         temporary.unlink(missing_ok=True)
 

--- a/mcp_server/tests/test_job_engine.py
+++ b/mcp_server/tests/test_job_engine.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
+from multisim_mcp import job_engine
 from multisim_mcp.job_engine import ExperimentJobManager, output_lease
 
 
@@ -109,6 +112,28 @@ def _wait_terminal(manager: ExperimentJobManager, job_id: str, seconds: float = 
 
 
 class DurableJobStateTest(unittest.TestCase):
+    def test_atomic_json_retries_transient_replace_denial(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "record.json"
+            real_replace = os.replace
+            attempts = 0
+
+            def transient_replace(source: str | bytes, destination: str | bytes) -> None:
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise PermissionError(13, "simulated sharing violation", destination)
+                real_replace(source, destination)
+
+            with patch.object(job_engine.os, "replace", side_effect=transient_replace):
+                job_engine._atomic_json(target, {"state": "queued"})
+
+            self.assertEqual(attempts, 2)
+            self.assertEqual(
+                json.loads(target.read_text(encoding="utf-8")),
+                {"state": "queued"},
+            )
+
     def test_default_worker_inherits_frontend_import_roots(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             manager = ExperimentJobManager(Path(tmp) / "state", start=False)
@@ -220,8 +245,8 @@ class WorkerRecoveryTest(unittest.TestCase):
                 )
                 first_result = _wait_terminal(first_manager, first["job_id"])
                 second_result = _wait_terminal(second_manager, second["job_id"])
-                self.assertEqual(first_result["state"], "succeeded")
-                self.assertEqual(second_result["state"], "succeeded")
+                self.assertEqual(first_result["state"], "succeeded", first_result)
+                self.assertEqual(second_result["state"], "succeeded", second_result)
                 self.assertFalse(marker.with_suffix(".violation").exists())
             finally:
                 first_manager.shutdown()


### PR DESCRIPTION
## 概要

修复两个 `ExperimentJobManager` 共享队列时，Windows 偶发因目标状态 JSON 正被读取而让 `os.replace` 返回 `WinError 5`，进而将任务错误标记为 `SCHEDULER_ERROR` 的问题。

## 修改

- 对 Windows 瞬时访问拒绝、共享冲突和锁冲突增加有界退避重试
- 保持其他 I/O 错误立即失败，永久权限错误在重试上限后仍会报告
- 增加确定性回归测试，并让租约测试失败时输出完整任务记录

## 验证

- x64 与 x86 共享队列压力测试各连续 100 次通过
- 本地 x86 完整测试 266/266 通过
- GitHub CI：`checks`、`windows-x86-protocol`、`linux-introspection` 全部通过

---

## English summary

Fixes a transient Windows sharing race where concurrent job-state readers could make atomic `os.replace` fail with `WinError 5`. Adds bounded retries for transient sharing errors and a deterministic regression test.