### PR TITLE
release: prepare Multisim MCP v1.1.0

### DIFF
--- a/.github/workflows/publish-dsh-plugin.yml
+++ b/.github/workflows/publish-dsh-plugin.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: Exact plugin version from package.json
         required: true
-        default: "1.0.0"
+        default: "1.1.0"
         type: string
       operation:
         description: Verify only, or stage an update to an existing npm package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 ### 中文
 
+- 暂无。
+
+### English
+
+- No changes yet.
+
+## [1.1.0] - 2026-08-21
+
+### 中文
+
+- 新增统一 `directory.manifest.json`：项目、完整实验和参数扫描/优化目录共享严格
+  schema、生命周期状态、修订号、生成器版本及产物大小/SHA-256；默认完整性校验拒绝
+  路径越界、符号链接、未知字段和篡改，实验与扫描均在原子发布事务内生成。
 - 新增传输无关模型运行时：支持 DeepSeek/OpenAI/Ollama 的有界非流式 Chat
   Completions、严格消息/工具/用量对象、每请求密钥轮换、及时取消和双重授权失败回退；
   `model` CLI 仅从显式 stdin/UTF-8 文件读取提示词且不公开工具。
@@ -64,6 +77,10 @@
 
 ### English
 
+- Added one strict `directory.manifest.json` contract for project, experiment,
+  and sweep/optimization folders, with lifecycle state, revisions, producer
+  version, artifact sizes/SHA-256 hashes, fail-closed integrity checks, and
+  generation inside the existing atomic experiment and sweep transactions.
 - Added a transport-neutral bounded Chat Completions runtime with normalized
   messages/tools/usage, per-request credential rotation, prompt cancellation,
   double-opt-in failover, a tool-free file/stdin CLI, and an allowlisted tool

--- a/README.en.md
+++ b/README.en.md
@@ -8,7 +8,7 @@ An unofficial local MCP server that lets an AI agent generate editable NI
 Multisim circuits from constrained SPICE input, run experiments, export data,
 and create reproducible reports.
 
-> The current stable release is `v1.0.0`. This project is not affiliated
+> The current stable release is `v1.1.0`. This project is not affiliated
 > with or endorsed by NI. A
 > locally installed and licensed Multisim 14+ environment is required. The
 > COM runs in an isolated 32-bit Python worker; the MCP frontend may use either
@@ -19,7 +19,7 @@ The completed development phases and release gates are recorded in the
 
 [PyPI package](https://pypi.org/project/multisim-mcp/) ·
 [Official MCP Registry entry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.yxy050208%2Fmultisim-mcp) ·
-[GitHub Release](https://github.com/yxy050208/multisim-mcp/releases/tag/v1.0.0)
+[GitHub Release](https://github.com/yxy050208/multisim-mcp/releases/tag/v1.1.0)
 
 ## End-to-end workflow
 
@@ -90,6 +90,8 @@ Stable:
   and crash/hang worker recovery.
 - versioned measurements, strict requirement verdicts, and four deterministic
   sweep modes.
+- versioned project, experiment, and optimization directory manifests with
+  revision tracking, lifecycle state, and SHA-256 integrity verification.
 
 Experimental but verified:
 
@@ -104,6 +106,8 @@ Experimental but verified:
 See [component coverage](docs/COMPONENT_COVERAGE.md) for precise boundaries.
 See [vendor macro-model compatibility](docs/VENDOR_SPICE_MODELS.md) for the
 editable-expansion and safe-file boundary.
+See [workspace manifests](docs/WORKSPACE_MANIFESTS.md) for the persistent
+directory schema and integrity contract.
 
 ## Public-release asset policy
 
@@ -135,7 +139,7 @@ See the [publishing guide](docs/PUBLISHING.md) and
 The simplest compatible deployment still installs into 32-bit Python:
 
 ```powershell
-C:\path\to\python32\python.exe -m pip install "multisim-mcp==1.0.0"
+C:\path\to\python32\python.exe -m pip install "multisim-mcp==1.1.0"
 C:\path\to\python32\Scripts\multisim-mcp.exe
 ```
 
@@ -164,7 +168,7 @@ npm install --global electronics-workbench-decoder@0.2.0
 .\run_server.ps1
 ```
 
-Version `v1.0.0` includes diagnostic and configuration commands.
+Version `v1.1.0` includes diagnostic and configuration commands.
 By default, they do not start Multisim or modify an existing client
 configuration:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 让 AI Agent 根据实验要求自动生成 Multisim 电路、运行仿真、提取实验数据，并导出
 电路图、CSV、波形图和实验报告。
 
-> 当前稳定发行版为 `v1.0.0`。项目非 NI 官方产品，需要本机安装并授权
+> 当前稳定发行版为 `v1.1.0`。项目非 NI 官方产品，需要本机安装并授权
 > Multisim 14+；COM 在独立 32 位 Python worker 中运行，MCP 前端可使用 32 或 64 位
 > Python。
 
@@ -15,12 +15,13 @@
 
 [PyPI 安装包](https://pypi.org/project/multisim-mcp/) ·
 [官方 MCP Registry 条目](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.yxy050208%2Fmultisim-mcp) ·
-[GitHub Release](https://github.com/yxy050208/multisim-mcp/releases/tag/v1.0.0)
+[GitHub Release](https://github.com/yxy050208/multisim-mcp/releases/tag/v1.1.0)
 
 ## 开源发布状态
 
-`1.0.0` 已发布到 PyPI，并以 `io.github.yxy050208/multisim-mcp` 收录到官方
-MCP Registry。由本地 NI 样例提取的 XML 模板不属于
+`1.1.0` 是当前发布候选；发布后将与 PyPI 和
+`io.github.yxy050208/multisim-mcp` 官方 MCP Registry 条目同步。由本地 NI
+样例提取的 XML 模板不属于
 MIT 代码授权范围，公开仓库默认不应包含这些文件。用户需要运行
 `tools/bootstrap_local_component_pack.py`，从自己已授权的 Multisim 安装生成本地模板包。
 
@@ -103,6 +104,7 @@ COM worker，服务重启后未完成任务会安全地重新排队。
 
 适配器语法与社区 JSON 接口见 [`docs/COMPONENT_ADAPTERS.md`](docs/COMPONENT_ADAPTERS.md)，
 真实版本边界见 [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md)。
+工作目录持久化格式见 [`docs/WORKSPACE_MANIFESTS.md`](docs/WORKSPACE_MANIFESTS.md)。
 1.0 真实回归覆盖适配器原理图打开/回导、变压器瞬态、继电器与功率器件工作点、
 晶振 AC、DFF 瞬态以及双语正式报告的完整事务发布。
 
@@ -116,6 +118,7 @@ COM worker，服务重启后未完成任务会安全地重新排队。
 - MCP stdio、运行环境诊断和报告生成。
 - 持久实验队列、进度/取消/超时、输出锁和崩溃/无响应 worker 恢复。
 - 版本化实验指标、严格 PASS/FAIL/未验证判定，以及四类确定性批量扫描。
+- 项目、实验和优化目录共用的版本化 manifest，支持修订、状态恢复和 SHA-256 完整性校验。
 
 实验性：
 
@@ -138,7 +141,7 @@ COM worker，服务重启后未完成任务会安全地重新排队。
 最简单的兼容部署仍是直接安装到 32 位 Python：
 
 ```powershell
-C:\path\to\python32\python.exe -m pip install "multisim-mcp==1.0.0"
+C:\path\to\python32\python.exe -m pip install "multisim-mcp==1.1.0"
 C:\path\to\python32\Scripts\multisim-mcp.exe
 ```
 
@@ -173,7 +176,7 @@ cd mcp_server
 模板包生成器会连接已授权的 Multisim，并新建一个临时空白电路以取得与当前安装版本
 一致的工程骨架；执行前请保存正在编辑的工作。alpha 版本生成的 schema 1 包需要重建。
 
-`v1.0.0` 提供安装诊断和配置生成命令。默认情况下它们不会启动
+`v1.1.0` 提供安装诊断和配置生成命令。默认情况下它们不会启动
 Multisim，也不会修改现有客户端配置：
 
 ```powershell

--- a/compatibility/deepseek-harness.json
+++ b/compatibility/deepseek-harness.json
@@ -24,7 +24,7 @@
     "mcp_prompts_bridged": false,
     "skill_discovery_root": ".dsh/skills",
     "bundle_package": "multisim-mcp-dsh-plugin",
-    "bundle_version": "1.0.0",
+    "bundle_version": "1.1.0",
     "bundle_path": "integrations/deepseek-harness",
     "tool_profiles": {
       "core": 26,

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -69,8 +69,8 @@ English: public CI remains COM-free; run the real Multisim suite locally.
 git add <逐项审查过的路径>
 git diff --cached --check
 python tools/release_audit.py
-git commit -m "release: v1.0.0"
-git tag -a v1.0.0 -m "Multisim MCP v1.0.0"
+git commit -m "release: v1.1.0"
+git tag -a v1.1.0 -m "Multisim MCP v1.1.0"
 ```
 
 推送、创建 GitHub Release 和上传附件应在再次检查暂存内容后手动执行。不要上传当前
@@ -78,14 +78,14 @@ git tag -a v1.0.0 -m "Multisim MCP v1.0.0"
 
 English: tag only after a final staged-file audit; never attach the local template wheel.
 
-## 6. v1.0.0 发布顺序
+## 6. v1.1.0 发布顺序
 
 1. 推送发布提交并等待 `CI` 全部通过。
-2. 推送签注标签 `v1.0.0`，由 Trusted Publishing 工作流发布 PyPI 包。
+2. 推送签注标签 `v1.1.0`，由 Trusted Publishing 工作流发布 PyPI 包。
 3. 核对 PyPI 文件 SHA-256，再创建 GitHub Release；附件只使用公开工作流构建的
    code-only wheel/sdist，不使用本地模板开发包。
 4. 运行 MCP Registry 发布工作流，并确认 `io.github.yxy050208/multisim-mcp` 显示
-   `1.0.0`。
+   `1.1.0`。
 5. 核对 Glama、awesome-mcp-servers 等社区目录的仓库链接和徽章；目录更新不能先于
    可安装包和 Registry 元数据。
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -91,8 +91,8 @@ adding an ignore rule does not remove a file that is already staged.
       pipeline, and job-engine regression set.
 - [x] Produce Chinese-first bilingual `RELEASE_NOTES_v1.1.0.md` and include it
       in the local release audit.
-- [ ] Push the release PR and wait for every public CI job to pass.
-- [ ] Build and inspect the final wheel/sdist from the reviewed release commit.
+- [x] Push the release PR and wait for every public CI job to pass.
+- [x] Build and inspect the final wheel/sdist from the reviewed release commit.
 - [ ] Push annotated tag `v1.1.0` and verify Trusted Publishing on PyPI.
 - [ ] Publish matching MCP Registry metadata and GitHub Release artifacts.
 - [ ] Re-check Glama and awesome-mcp-servers metadata after publication.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -79,14 +79,32 @@ adding an ignore rule does not remove a file that is already staged.
 - [x] Publish matching MCP Registry metadata and GitHub Release artifacts.
 - [x] Verify Glama and awesome-mcp-servers directory metadata after publication.
 
-## DeepSeek Harness npm bundle 1.0.0
+## Required before v1.1.0
+
+- [x] Complete the versioned project/experiment/optimization directory manifest
+      contract and integrate it into atomic experiment and sweep publication.
+- [x] Synchronize `pyproject.toml`, `multisim_mcp.__version__`, and both
+      `server.json` version fields at `1.1.0`.
+- [x] Keep public protocol compatibility at 55 tools, 19 Resource templates,
+      and 5 prompts.
+- [x] Pass 271 COM-free tests on 32-bit Python plus the 64-bit core manifest,
+      pipeline, and job-engine regression set.
+- [x] Produce Chinese-first bilingual `RELEASE_NOTES_v1.1.0.md` and include it
+      in the local release audit.
+- [ ] Push the release PR and wait for every public CI job to pass.
+- [ ] Build and inspect the final wheel/sdist from the reviewed release commit.
+- [ ] Push annotated tag `v1.1.0` and verify Trusted Publishing on PyPI.
+- [ ] Publish matching MCP Registry metadata and GitHub Release artifacts.
+- [ ] Re-check Glama and awesome-mcp-servers metadata after publication.
+
+## DeepSeek Harness npm bundle 1.1.0
 
 - [x] Pin the official Harness CLI and MCP client compatibility baseline.
 - [x] Restrict the npm tarball to four reviewed files.
 - [x] Add a Registry ownership/version guard with unit tests.
 - [x] Add verify-only and stage-existing GitHub Actions paths.
 - [ ] Re-run the Registry guard immediately before the first publication.
-- [ ] Publish `multisim-mcp-dsh-plugin@1.0.0` interactively with maintainer 2FA.
+- [ ] Publish `multisim-mcp-dsh-plugin@1.1.0` interactively with maintainer 2FA.
 - [ ] Configure `publish-dsh-plugin.yml` as a stage-only npm Trusted Publisher.
 - [ ] Protect the GitHub `npm` Environment with required reviewers.
 - [ ] Disallow traditional publish tokens and verify package provenance on the

--- a/docs/RELEASE_NOTES_v1.1.0.md
+++ b/docs/RELEASE_NOTES_v1.1.0.md
@@ -1,0 +1,76 @@
+# Multisim MCP v1.1.0
+
+这是从“Multisim 自动化工具集合”走向可扩展 EDA 自动化平台内核的首个版本。
+它保留 v1.0 的电路生成、真实仿真、数据导出和双语实验报告闭环，同时加入稳定的
+EDA 数据边界、可注入后端、模型运行时、DeepSeek/DeepSeek Harness 集成，以及可验证
+的项目、实验和优化目录契约。
+
+## 主要变化
+
+- 新增传输无关的 `CircuitDesign`、`DesignPatch`、`ArtifactSet` 和
+  `ExperimentRequest`，让电路设计、补丁、产物及实验请求不再依赖 MCP 或 COM。
+- 新增 `EdaBackend` 能力发现、注册和调度服务；Multisim 是第一个适配后端，后续可在
+  不破坏上层接口的前提下扩展其他 EDA 平台。
+- `create_schematic_from_netlist`、`run_spice_netlist` 和持久实验任务逐步归一到同一应用
+  服务边界，32 位 COM worker 与 32/64 位 MCP 前端继续隔离运行。
+- 新增 DeepSeek、OpenAI、Ollama 与兼容端点的自助配置和有界模型运行时；密钥只以
+  环境变量引用保存，输出脱敏，远程明文 HTTP 和未授权工具调用会被拒绝。
+- 新增只读 `model-diagnose` 工具循环，可对严格 `CircuitDesign` 或仅解析的安全 SPICE
+  网表执行摘要、元件分页、网络连通性和结构检查；不会触发 Multisim 或修改工程。
+- 增加 DeepSeek Harness 的 profiles、工具描述、skills 和 npm bundle 源码。该 bundle
+  是独立发布物，源码版本与 Python/MCP 同步为 `1.1.0`，但不会随
+  Python 包自动发布；npm 仍需维护者单独完成 2FA 和 Registry 守卫。
+- 将真实课程设计回归中暴露的频率、幅度和 THD 测量问题纳入实现，并扩展受控厂商
+  subcircuit 和双 LM324 等复杂模拟电路路径。
+- 新增严格 `directory.manifest.json`：项目、完整实验和参数扫描/优化目录共享 schema、
+  生命周期状态、修订号、生成器版本以及每项产物的大小和 SHA-256。读取时默认拒绝路径
+  越界、符号链接、未知字段和内容篡改。
+- 修复 Windows 下持久任务状态文件原子替换偶发共享冲突的问题，并以有限重试保持
+  失败关闭语义。
+
+## 安装
+
+真实 Multisim 自动化要求 Windows、已授权的 Multisim 14+，以及可供 COM worker
+使用的 32 位 Python 3.10+：
+
+```powershell
+C:\path\to\python32\python.exe -m pip install "multisim-mcp==1.1.0"
+C:\path\to\python32\Scripts\multisim-mcp.exe doctor --lang zh --connect
+```
+
+MCP 前端也可运行在 64 位 Python，并通过 `MULTISIM_MCP_WORKER_PYTHON` 指向安装了本
+项目与 `pywin32` 的 32 位解释器。Linux/Docker 仍仅支持协议 introspection、配置和
+兼容性检查，不能运行 Multisim COM 自动化。
+
+公开包不包含 NI 软件、样例、解码电路或从本地安装提取的 XML 模板。元件模板包必须
+由用户从自己已授权的 Multisim 安装中本地生成。
+
+## 协议与验证
+
+- 保持 55 个 MCP tools、19 个 Resource templates 和 5 个中英双语 prompts。
+- Python 要求保持 `>=3.10`；32 位 Python 负责真实 COM，64 位前端通过持久 worker
+  调用它。
+- 发布预检已在 32 位 Python 3.12 上通过 271 项无 COM 测试，并在 64 位 Python
+  3.10 上通过目录清单、实验管线和任务引擎核心回归。
+- `directory.manifest.json` 与正式实验 `manifest.json` 职责不同：前者约束目录级
+  生命周期和全部产物完整性，后者继续保存实验复现语义。
+- 公开 CI 与最终 wheel/sdist 内容审计将在发布提交后再次执行；真实 Multisim 回归仍
+  必须在安装并授权 NI 软件的本地 Windows 主机上完成。
+
+## 升级说明
+
+v1.0 客户端配置和 MCP 工具调用保持兼容。新目录清单由新实验和参数扫描自动生成；
+旧输出目录不会被静默改写。如需验证新目录，可读取
+[`WORKSPACE_MANIFESTS.md`](WORKSPACE_MANIFESTS.md) 中的格式和安全约束。
+
+## English summary
+
+Version 1.1 evolves Multisim MCP into an extensible EDA automation core while
+preserving the v1.0 circuit-generation, real-simulation, export, and bilingual
+report workflow. It introduces transport-independent design and experiment
+models, injectable EDA backends, bounded DeepSeek/OpenAI/Ollama integration,
+read-only model-assisted diagnosis, and strict versioned directory manifests
+for projects, experiments, and optimization runs. The public protocol remains
+compatible at 55 tools, 19 Resource templates, and 5 prompts. Real Multisim
+automation still requires licensed NI software on Windows and a 32-bit Python
+COM worker.

--- a/docs/ROADMAP_TO_2.0.md
+++ b/docs/ROADMAP_TO_2.0.md
@@ -51,7 +51,7 @@ AI client / Visual Workbench
 - [x] 把同步、验证和持久 worker 实验入口从 MCP 工具迁移到应用服务。
 - [x] 将事务发布/报告执行器从 `server.py` 提取为可注入独立流水线组件。
 - [x] 将 Multisim COM/编解码操作保留在独立 32 位 worker 中，支持 64 位前端。
-- [ ] 为项目目录、实验目录和优化目录增加版本化 manifest。
+- [x] 为项目目录、实验目录和优化目录增加版本化 manifest。
 - [x] 保持现有 55 个工具、19 个 Resource 模板和 5 个 Prompt 兼容。
 - [x] 规划 DeepSeek 与 DeepSeek Harness 的分层适配。
 - [x] 增加 DeepSeek Harness 客户端配置生成器。

--- a/docs/WORKSPACE_MANIFESTS.md
+++ b/docs/WORKSPACE_MANIFESTS.md
@@ -1,0 +1,73 @@
+# 版本化工作目录 Manifest / Versioned Workspace Manifests
+
+Multisim MCP 使用根目录下固定名称 `directory.manifest.json` 描述可长期恢复和审计的
+项目、实验与优化目录。该文件属于传输无关的 EDA Core：MCP、本地 API、未来的可视化
+工作台和不同 EDA 后端共享同一格式。
+
+## 适用目录
+
+- `project`：电路设计、模型引用、补丁和项目级附件；
+- `experiment`：一次原理图生成、仿真、验收和报告事务；
+- `optimization`：参数扫描、候选比较及后续的有界优化运行。
+
+当前完整实验和参数扫描会在事务发布前自动生成 manifest。项目目录和未来优化器可直接
+调用 `write_directory_manifest` 使用同一契约。
+
+## Schema 1
+
+```json
+{
+  "schema_version": 1,
+  "manifest_type": "multisim-mcp-directory",
+  "manifest_id": "manifest-0123456789abcdef01234567",
+  "directory_kind": "experiment",
+  "entity_id": "exp-0123456789abcdef01234567",
+  "state": "succeeded",
+  "revision": 0,
+  "created_at": "2026-08-21T00:00:00Z",
+  "updated_at": "2026-08-21T00:00:00Z",
+  "producer": {"name": "multisim-mcp", "version": "1.1.0"},
+  "artifacts": [
+    {
+      "path": "result.raw",
+      "role": "simulation-data",
+      "size": 1234,
+      "sha256": "<64 lowercase hexadecimal characters>"
+    }
+  ],
+  "metadata": {"verified": true}
+}
+```
+
+所有产物路径必须是使用 `/` 的相对路径，不能包含 `..`、绝对路径或符号链接。
+manifest 不散列自身，以避免递归摘要。重复写入同一目录时保留 `created_at`，并递增
+`revision`。
+
+## 完整性与失败行为
+
+`read_directory_manifest(..., verify=True)` 默认逐项核对文件大小和 SHA-256。以下情况
+会失败关闭：
+
+- schema 版本、类型、目录种类或字段未知；
+- 产物缺失、被替换、大小变化或摘要不匹配；
+- 路径越界、符号链接、重复路径或非有限 JSON 数值；
+- manifest 超过大小限制或产物条目超过硬上限。
+
+写入使用同目录临时文件、`fsync` 和原子替换。Windows 短暂共享冲突只进行有界退避
+重试，永久权限错误仍会返回给调用方。
+
+## 与 `manifest.json` 的区别
+
+实验目录中的 `manifest.json` 是正式报告使用的可复现产物清单；
+`directory.manifest.json` 是项目生命周期、状态、修订和目录恢复契约。后者会散列前者，
+而前者不反向散列目录 manifest，避免循环依赖。
+
+## English summary
+
+`directory.manifest.json` is the strict, versioned persistence contract shared
+by project, experiment, and optimization folders. It records lifecycle state,
+revision, producer version, portable relative artifact paths, sizes, and
+SHA-256 digests. Reads verify integrity by default and reject unknown schemas,
+path traversal, symlinks, missing files, and tampering. Complete experiments
+and sweeps create the manifest inside their existing atomic publication
+transactions.

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multisim-mcp-dsh-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "DeepSeek Harness bundle for the Multisim MCP server",
   "license": "MIT",
   "type": "module",

--- a/mcp_server/multisim_mcp/__init__.py
+++ b/mcp_server/multisim_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Unofficial Multisim MCP server."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/mcp_server/multisim_mcp/experiment_pipeline.py
+++ b/mcp_server/multisim_mcp/experiment_pipeline.py
@@ -25,6 +25,7 @@ from .formal_report import export_formal_reports
 from .job_engine import output_lease
 from .safety import validate_analysis_commands, validate_spice_netlist
 from .spice_raw import parse_raw, plot_svg
+from .workspace_manifest import DIRECTORY_MANIFEST_NAME, write_directory_manifest
 
 
 Checkpoint = Callable[[str, int, str], None]
@@ -49,7 +50,27 @@ _BASE_ARTIFACT_NAMES = (
     "report.zh-CN.pdf",
     "report.en.pdf",
     "manifest.json",
+    DIRECTORY_MANIFEST_NAME,
 )
+
+_ARTIFACT_ROLES = {
+    "circuit.ms14": "schematic",
+    "circuit.ms14.xml": "schematic-source",
+    "schematic.png": "schematic-image",
+    "data.csv": "simulation-data",
+    "result.raw": "simulation-data",
+    "run.log": "log",
+    "run.txt": "analysis-commands",
+    "circuit.cir": "netlist",
+    "plot.svg": "plot",
+    "report.md": "report",
+    "report.zh-CN.html": "report",
+    "report.en.html": "report",
+    "report.zh-CN.pdf": "report",
+    "report.en.pdf": "report",
+    "manifest.json": "reproducibility-manifest",
+    "verification.json": "verification",
+}
 
 
 def _markdown_text(value: object) -> str:
@@ -413,7 +434,24 @@ class MultisimExperimentPipeline:
                 "plot.svg",
                 verification,
             )
-            self._report_exporter(stage, experiment_id_for_output_dir(root))
+            stable_experiment_id = experiment_id_for_output_dir(root)
+            self._report_exporter(stage, stable_experiment_id)
+            write_directory_manifest(
+                stage,
+                directory_kind="experiment",
+                entity_id=stable_experiment_id,
+                state="succeeded",
+                artifacts={
+                    name: _ARTIFACT_ROLES.get(name, "artifact")
+                    for name in manifest_names
+                    if name != DIRECTORY_MANIFEST_NAME
+                },
+                metadata={
+                    "title": title,
+                    "verified": requirements is not None,
+                    "requirement_count": len(requirements or ()),
+                },
+            )
 
             missing = [
                 str(stage / name)

--- a/mcp_server/multisim_mcp/server.py
+++ b/mcp_server/multisim_mcp/server.py
@@ -91,11 +91,16 @@ from multisim_mcp.sweep_resources import (
     read_sweep_summary,
     read_sweep_text,
     register_sweep,
+    sweep_id_for_output_dir,
 )
 from multisim_mcp.tool_profiles import (
     selected_tool_profile,
     tool_enabled,
     tool_profile_status,
+)
+from multisim_mcp.workspace_manifest import (
+    DIRECTORY_MANIFEST_NAME,
+    write_directory_manifest,
 )
 
 
@@ -1655,6 +1660,38 @@ def _run_experiment_sweep_impl(
                             *(values.get(name, "") for name in measurement_ids),
                         ]
                     )
+            sweep_artifacts: dict[str, str] = {}
+            for artifact_path in sorted(stage.rglob("*")):
+                if artifact_path.is_symlink():
+                    raise ValueError(
+                        "Sweep artifacts must not contain symbolic links: "
+                        f"{artifact_path.relative_to(stage).as_posix()}"
+                    )
+                if artifact_path.is_file():
+                    relative = artifact_path.relative_to(stage).as_posix()
+                    if relative == DIRECTORY_MANIFEST_NAME:
+                        continue
+                    sweep_artifacts[relative] = (
+                        "sweep-summary"
+                        if relative == "summary.json"
+                        else "sweep-data"
+                        if relative == "data.csv"
+                        else "run-artifact"
+                    )
+            write_directory_manifest(
+                stage,
+                directory_kind="optimization",
+                entity_id=sweep_id_for_output_dir(root),
+                state="succeeded",
+                artifacts=sweep_artifacts,
+                metadata={
+                    "operation": "experiment-sweep",
+                    "title": plan["title"],
+                    "mode": plan["mode"],
+                    "run_count": total,
+                    "seed": plan["seed"],
+                },
+            )
             notify("sweep_publish", 94, "Publishing the complete sweep transaction")
             backup = root.parent / f".{root.name}.backup-{uuid.uuid4().hex}"
             had_root = root.exists()

--- a/mcp_server/multisim_mcp/sweep_resources.py
+++ b/mcp_server/multisim_mcp/sweep_resources.py
@@ -24,6 +24,11 @@ def _stable_id(root: Path) -> str:
     return "sweep-" + hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:24]
 
 
+def sweep_id_for_output_dir(output_dir: str | Path) -> str:
+    """Return the stable opaque ID without registering or reading artifacts."""
+    return _stable_id(Path(output_dir).expanduser().resolve())
+
+
 def _safe_file(root: Path, name: str) -> Path:
     filename = _FILES.get(name)
     if filename is None:

--- a/mcp_server/multisim_mcp/workspace_manifest.py
+++ b/mcp_server/multisim_mcp/workspace_manifest.py
@@ -1,0 +1,444 @@
+"""Versioned, transport-neutral manifests for persistent workspace directories."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Any, Final, Iterable, Mapping
+
+from multisim_mcp import __version__
+
+
+DIRECTORY_MANIFEST_SCHEMA_VERSION: Final = 1
+DIRECTORY_MANIFEST_NAME: Final = "directory.manifest.json"
+MAX_DIRECTORY_ARTIFACTS: Final = 20_000
+MAX_MANIFEST_BYTES: Final = 8 * 1024 * 1024
+MAX_METADATA_BYTES: Final = 1024 * 1024
+
+_MANIFEST_TYPE: Final = "multisim-mcp-directory"
+_DIRECTORY_KINDS: Final = frozenset({"project", "experiment", "optimization"})
+_STATES: Final = frozenset(
+    {"planned", "active", "running", "succeeded", "failed", "cancelled", "archived"}
+)
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_ROLE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+JsonScalar = str | int | float | bool | None
+FrozenJson = JsonScalar | tuple["FrozenJson", ...] | Mapping[str, "FrozenJson"]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _text(value: object, name: str, maximum: int = 4096) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    normalized = value.strip()
+    if not normalized or "\x00" in normalized or len(normalized) > maximum:
+        raise ValueError(f"{name} is empty, invalid, or too long")
+    return normalized
+
+
+def _identifier(value: object, name: str) -> str:
+    normalized = _text(value, name, 128)
+    if not _IDENTIFIER.fullmatch(normalized):
+        raise ValueError(f"{name} must be a stable identifier")
+    return normalized
+
+
+def _timestamp(value: object, name: str) -> str:
+    normalized = _text(value, name, 64)
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{name} must include a timezone")
+    return normalized
+
+
+def _freeze_json(value: Any, path: str = "metadata") -> FrozenJson:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} must contain only finite numbers")
+        return value
+    if isinstance(value, Mapping):
+        frozen: dict[str, FrozenJson] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key or "\x00" in key:
+                raise ValueError(f"{path} keys must be non-empty strings")
+            frozen[key] = _freeze_json(item, f"{path}.{key}")
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_json(item, f"{path}[]") for item in value)
+    raise ValueError(f"{path} is not JSON-compatible")
+
+
+def _thaw_json(value: FrozenJson) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _relative_path(value: object) -> str:
+    normalized = _text(value, "artifact.path", 4096)
+    if "\\" in normalized:
+        raise ValueError("artifact.path must use portable forward slashes")
+    path = PurePosixPath(normalized)
+    if path.is_absolute() or not path.parts or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("artifact.path must be a contained relative path")
+    portable = path.as_posix()
+    if portable == DIRECTORY_MANIFEST_NAME:
+        raise ValueError("the directory manifest cannot hash itself")
+    return portable
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _root_directory(root: str | Path) -> Path:
+    candidate = Path(root).expanduser()
+    if candidate.is_symlink():
+        raise ValueError("workspace root must not be a symbolic link")
+    resolved = candidate.resolve()
+    if not resolved.is_dir():
+        raise FileNotFoundError(f"workspace directory does not exist: {resolved}")
+    return resolved
+
+
+def _contained_file(root: Path, relative: str) -> Path:
+    portable = _relative_path(relative)
+    candidate = root
+    for part in PurePosixPath(portable).parts:
+        candidate = candidate / part
+        if candidate.is_symlink():
+            raise ValueError(f"manifest artifacts must not traverse symlinks: {portable}")
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"manifest artifact escapes its workspace: {portable}") from exc
+    if not resolved.is_file():
+        raise FileNotFoundError(f"manifest artifact is missing: {portable}")
+    return resolved
+
+
+def _atomic_json(path: Path, value: object) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8", newline="\n") as handle:
+            json.dump(value, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        delay = 0.005
+        for attempt in range(8):
+            try:
+                os.replace(temporary, path)
+                break
+            except OSError as exc:
+                transient = isinstance(exc, PermissionError) or getattr(
+                    exc, "winerror", None
+                ) in {5, 32, 33}
+                if not transient or attempt == 7:
+                    raise
+                time.sleep(delay)
+                delay = min(delay * 2, 0.08)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+@dataclass(frozen=True, slots=True)
+class DirectoryArtifact:
+    """One immutable file reference stored in a directory manifest."""
+
+    path: str
+    role: str
+    size: int
+    sha256: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", _relative_path(self.path))
+        role = _text(self.role, "artifact.role", 64)
+        if not _ROLE.fullmatch(role):
+            raise ValueError("artifact.role must be a lowercase stable name")
+        object.__setattr__(self, "role", role)
+        if isinstance(self.size, bool) or not isinstance(self.size, int) or self.size < 0:
+            raise ValueError("artifact.size must be a non-negative integer")
+        if not isinstance(self.sha256, str) or not _SHA256.fullmatch(self.sha256):
+            raise ValueError("artifact.sha256 must be a lowercase SHA-256 digest")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "role": self.role,
+            "size": self.size,
+            "sha256": self.sha256,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "DirectoryArtifact":
+        if not isinstance(value, Mapping):
+            raise ValueError("DirectoryArtifact must be an object")
+        unknown = set(value) - {"path", "role", "size", "sha256"}
+        if unknown:
+            raise ValueError(f"DirectoryArtifact contains unknown fields: {sorted(unknown)}")
+        return cls(
+            path=value.get("path", ""),
+            role=value.get("role", ""),
+            size=value.get("size", -1),
+            sha256=value.get("sha256", ""),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DirectoryManifest:
+    """Strict schema shared by project, experiment, and optimization folders."""
+
+    manifest_id: str
+    directory_kind: str
+    entity_id: str
+    state: str
+    revision: int
+    created_at: str
+    updated_at: str
+    producer_version: str
+    artifacts: tuple[DirectoryArtifact, ...]
+    metadata: Mapping[str, FrozenJson] = field(default_factory=dict)
+    schema_version: int = DIRECTORY_MANIFEST_SCHEMA_VERSION
+    manifest_type: str = _MANIFEST_TYPE
+
+    def __post_init__(self) -> None:
+        if self.schema_version != DIRECTORY_MANIFEST_SCHEMA_VERSION:
+            raise ValueError(
+                f"DirectoryManifest schema_version must be {DIRECTORY_MANIFEST_SCHEMA_VERSION}"
+            )
+        if self.manifest_type != _MANIFEST_TYPE:
+            raise ValueError(f"DirectoryManifest manifest_type must be {_MANIFEST_TYPE}")
+        object.__setattr__(self, "manifest_id", _identifier(self.manifest_id, "manifest_id"))
+        if self.directory_kind not in _DIRECTORY_KINDS:
+            raise ValueError("directory_kind must be project, experiment, or optimization")
+        object.__setattr__(self, "entity_id", _identifier(self.entity_id, "entity_id"))
+        if self.state not in _STATES:
+            raise ValueError(f"unsupported directory manifest state: {self.state!r}")
+        if isinstance(self.revision, bool) or not isinstance(self.revision, int) or self.revision < 0:
+            raise ValueError("revision must be a non-negative integer")
+        object.__setattr__(self, "created_at", _timestamp(self.created_at, "created_at"))
+        object.__setattr__(self, "updated_at", _timestamp(self.updated_at, "updated_at"))
+        object.__setattr__(
+            self, "producer_version", _text(self.producer_version, "producer_version", 64)
+        )
+        artifacts = tuple(self.artifacts)
+        if not artifacts or len(artifacts) > MAX_DIRECTORY_ARTIFACTS:
+            raise ValueError(
+                f"artifacts must contain between 1 and {MAX_DIRECTORY_ARTIFACTS} entries"
+            )
+        if any(not isinstance(item, DirectoryArtifact) for item in artifacts):
+            raise ValueError("artifacts must contain DirectoryArtifact values")
+        paths = [item.path.casefold() for item in artifacts]
+        if len(paths) != len(set(paths)):
+            raise ValueError("directory manifest contains duplicate artifact paths")
+        object.__setattr__(self, "artifacts", artifacts)
+        frozen = _freeze_json(self.metadata)
+        assert isinstance(frozen, Mapping)
+        encoded_metadata = json.dumps(
+            _thaw_json(frozen), ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8")
+        if len(encoded_metadata) > MAX_METADATA_BYTES:
+            raise ValueError("metadata exceeds the size limit")
+        object.__setattr__(self, "metadata", frozen)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "manifest_type": self.manifest_type,
+            "manifest_id": self.manifest_id,
+            "directory_kind": self.directory_kind,
+            "entity_id": self.entity_id,
+            "state": self.state,
+            "revision": self.revision,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "producer": {"name": "multisim-mcp", "version": self.producer_version},
+            "artifacts": [item.to_dict() for item in self.artifacts],
+            "metadata": _thaw_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "DirectoryManifest":
+        if not isinstance(value, Mapping):
+            raise ValueError("DirectoryManifest must be an object")
+        allowed = {
+            "schema_version",
+            "manifest_type",
+            "manifest_id",
+            "directory_kind",
+            "entity_id",
+            "state",
+            "revision",
+            "created_at",
+            "updated_at",
+            "producer",
+            "artifacts",
+            "metadata",
+        }
+        unknown = set(value) - allowed
+        if unknown:
+            raise ValueError(f"DirectoryManifest contains unknown fields: {sorted(unknown)}")
+        producer = value.get("producer")
+        if not isinstance(producer, Mapping) or set(producer) != {"name", "version"}:
+            raise ValueError("producer must contain exactly name and version")
+        if producer.get("name") != "multisim-mcp":
+            raise ValueError("producer.name must be multisim-mcp")
+        raw_artifacts = value.get("artifacts")
+        if not isinstance(raw_artifacts, (list, tuple)):
+            raise ValueError("artifacts must be an array")
+        metadata = value.get("metadata", {})
+        if not isinstance(metadata, Mapping):
+            raise ValueError("metadata must be an object")
+        return cls(
+            schema_version=value.get("schema_version", -1),
+            manifest_type=value.get("manifest_type", ""),
+            manifest_id=value.get("manifest_id", ""),
+            directory_kind=value.get("directory_kind", ""),
+            entity_id=value.get("entity_id", ""),
+            state=value.get("state", ""),
+            revision=value.get("revision", -1),
+            created_at=value.get("created_at", ""),
+            updated_at=value.get("updated_at", ""),
+            producer_version=producer.get("version", ""),
+            artifacts=tuple(DirectoryArtifact.from_dict(item) for item in raw_artifacts),
+            metadata=metadata,
+        )
+
+
+def _manifest_id(directory_kind: str, entity_id: str) -> str:
+    digest = hashlib.sha256(f"{directory_kind}:{entity_id}".encode("utf-8")).hexdigest()[:24]
+    return f"manifest-{digest}"
+
+
+def write_directory_manifest(
+    root: str | Path,
+    *,
+    directory_kind: str,
+    entity_id: str,
+    state: str,
+    artifacts: Mapping[str, str] | Iterable[str],
+    metadata: Mapping[str, Any] | None = None,
+) -> DirectoryManifest:
+    """Atomically create or revise a manifest from an explicit artifact allowlist."""
+    workspace = _root_directory(root)
+    normalized_id = _identifier(entity_id, "entity_id")
+    if directory_kind not in _DIRECTORY_KINDS:
+        raise ValueError("directory_kind must be project, experiment, or optimization")
+    if isinstance(artifacts, Mapping):
+        requested = list(artifacts.items())
+    else:
+        requested = [(path, "artifact") for path in artifacts]
+    if not requested or len(requested) > MAX_DIRECTORY_ARTIFACTS:
+        raise ValueError(
+            f"artifacts must contain between 1 and {MAX_DIRECTORY_ARTIFACTS} entries"
+        )
+    entries: list[DirectoryArtifact] = []
+    for relative, role in requested:
+        portable = _relative_path(relative)
+        path = _contained_file(workspace, portable)
+        entries.append(
+            DirectoryArtifact(
+                path=portable,
+                role=role,
+                size=path.stat().st_size,
+                sha256=_sha256_file(path),
+            )
+        )
+    entries.sort(key=lambda item: item.path.casefold())
+
+    path = workspace / DIRECTORY_MANIFEST_NAME
+    now = _utc_now()
+    revision = 0
+    created_at = now
+    if path.exists():
+        existing = read_directory_manifest(workspace, verify=False)
+        if existing.directory_kind != directory_kind or existing.entity_id != normalized_id:
+            raise ValueError("existing directory manifest belongs to a different entity")
+        revision = existing.revision + 1
+        created_at = existing.created_at
+    manifest = DirectoryManifest(
+        manifest_id=_manifest_id(directory_kind, normalized_id),
+        directory_kind=directory_kind,
+        entity_id=normalized_id,
+        state=state,
+        revision=revision,
+        created_at=created_at,
+        updated_at=now,
+        producer_version=__version__,
+        artifacts=tuple(entries),
+        metadata=metadata or {},
+    )
+    _atomic_json(path, manifest.to_dict())
+    return manifest
+
+
+def read_directory_manifest(
+    root: str | Path, *, verify: bool = True
+) -> DirectoryManifest:
+    """Read a strict manifest and optionally verify every referenced artifact."""
+    workspace = _root_directory(root)
+    path = workspace / DIRECTORY_MANIFEST_NAME
+    if path.is_symlink() or not path.is_file():
+        raise FileNotFoundError(f"directory manifest is missing: {path}")
+    if path.stat().st_size > MAX_MANIFEST_BYTES:
+        raise ValueError("directory manifest exceeds the size limit")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"directory manifest is not valid JSON: {exc}") from exc
+    manifest = DirectoryManifest.from_dict(payload)
+    if verify:
+        verify_directory_manifest(workspace, manifest)
+    return manifest
+
+
+def verify_directory_manifest(
+    root: str | Path, manifest: DirectoryManifest | None = None
+) -> None:
+    """Fail closed when a manifest artifact is missing, replaced, or modified."""
+    workspace = _root_directory(root)
+    checked = manifest or read_directory_manifest(workspace, verify=False)
+    for artifact in checked.artifacts:
+        path = _contained_file(workspace, artifact.path)
+        if path.stat().st_size != artifact.size:
+            raise ValueError(f"manifest artifact size mismatch: {artifact.path}")
+        if _sha256_file(path) != artifact.sha256:
+            raise ValueError(f"manifest artifact SHA-256 mismatch: {artifact.path}")
+
+
+__all__ = [
+    "DIRECTORY_MANIFEST_NAME",
+    "DIRECTORY_MANIFEST_SCHEMA_VERSION",
+    "DirectoryArtifact",
+    "DirectoryManifest",
+    "read_directory_manifest",
+    "verify_directory_manifest",
+    "write_directory_manifest",
+]

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multisim-mcp"
-version = "1.0.0"
+version = "1.1.0"
 description = "Unofficial MCP server for NI Multisim Automation API"
 readme = "README.md"
 license = "MIT"

--- a/mcp_server/tests/test_dsh_plugin_release.py
+++ b/mcp_server/tests/test_dsh_plugin_release.py
@@ -39,10 +39,10 @@ def existing_package(*, version: str = "0.9.0", repository: str | None = None) -
 
 def npm_pack_package() -> dict:
     return {
-        "id": "multisim-mcp-dsh-plugin@1.0.0",
+        "id": "multisim-mcp-dsh-plugin@1.1.0",
         "name": "multisim-mcp-dsh-plugin",
-        "version": "1.0.0",
-        "filename": "multisim-mcp-dsh-plugin-1.0.0.tgz",
+        "version": "1.1.0",
+        "filename": "multisim-mcp-dsh-plugin-1.1.0.tgz",
         "size": 100,
         "unpackedSize": 200,
         "files": [
@@ -56,7 +56,7 @@ def npm_pack_package() -> dict:
 
 class DshPluginReleaseTest(unittest.TestCase):
     def test_local_package_boundary_passes(self) -> None:
-        result = release.run_checks(REPO_ROOT, expected_version="1.0.0")
+        result = release.run_checks(REPO_ROOT, expected_version="1.1.0")
         self.assertTrue(result["success"])
         self.assertFalse(result["registry_checked"])
         self.assertIsNone(result["registry_state"])
@@ -64,7 +64,7 @@ class DshPluginReleaseTest(unittest.TestCase):
     def test_unclaimed_name_is_valid_for_first_publication(self) -> None:
         result = release.run_checks(
             REPO_ROOT,
-            expected_version="1.0.0",
+            expected_version="1.1.0",
             check_registry=True,
             registry_loader=lambda name, timeout: None,
         )
@@ -96,7 +96,7 @@ class DshPluginReleaseTest(unittest.TestCase):
 
     def test_existing_target_version_is_rejected(self) -> None:
         remote = existing_package(
-            version="1.0.0",
+            version="1.1.0",
             repository="https://github.com/yxy050208/multisim-mcp",
         )
         result = release.run_checks(
@@ -118,7 +118,7 @@ class DshPluginReleaseTest(unittest.TestCase):
         self.assertEqual(result["findings"][0]["check"], "registry-ownership")
 
     def test_requested_version_must_match_package(self) -> None:
-        result = release.run_checks(REPO_ROOT, expected_version="1.0.1")
+        result = release.run_checks(REPO_ROOT, expected_version="1.1.1")
         self.assertFalse(result["success"])
         self.assertEqual(result["findings"][0]["check"], "requested-version")
 
@@ -126,15 +126,15 @@ class DshPluginReleaseTest(unittest.TestCase):
         result = pack_check.validate_pack_result(
             [npm_pack_package()],
             expected_name="multisim-mcp-dsh-plugin",
-            expected_version="1.0.0",
+            expected_version="1.1.0",
         )
-        self.assertEqual(result["filename"], "multisim-mcp-dsh-plugin-1.0.0.tgz")
+        self.assertEqual(result["filename"], "multisim-mcp-dsh-plugin-1.1.0.tgz")
 
     def test_npm_12_object_pack_output_is_supported(self) -> None:
         result = pack_check.validate_pack_result(
             {"multisim-mcp-dsh-plugin": npm_pack_package()},
             expected_name="multisim-mcp-dsh-plugin",
-            expected_version="1.0.0",
+            expected_version="1.1.0",
         )
         self.assertEqual(result["files"], sorted(pack_check.EXPECTED_FILES))
 
@@ -145,7 +145,7 @@ class DshPluginReleaseTest(unittest.TestCase):
             pack_check.validate_pack_result(
                 {"multisim-mcp-dsh-plugin": package},
                 expected_name="multisim-mcp-dsh-plugin",
-                expected_version="1.0.0",
+                expected_version="1.1.0",
             )
 
 

--- a/mcp_server/tests/test_experiment_pipeline.py
+++ b/mcp_server/tests/test_experiment_pipeline.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 from multisim_mcp.experiment_pipeline import MultisimExperimentPipeline
+from multisim_mcp.workspace_manifest import (
+    DIRECTORY_MANIFEST_NAME,
+    read_directory_manifest,
+)
 
 
 RAW_FIXTURE = """Title: fixture
@@ -38,6 +42,7 @@ ARTIFACT_NAMES = (
     "report.zh-CN.pdf",
     "report.en.pdf",
     "manifest.json",
+    DIRECTORY_MANIFEST_NAME,
 )
 
 
@@ -133,6 +138,14 @@ class ExperimentPipelineTest(unittest.TestCase):
             )
             self.assertFalse(
                 list(output.parent.glob(f".{output.name}.multisim-mcp-*"))
+            )
+            directory_manifest = read_directory_manifest(output)
+            self.assertEqual(directory_manifest.directory_kind, "experiment")
+            self.assertEqual(directory_manifest.state, "succeeded")
+            self.assertEqual(directory_manifest.metadata["verified"], False)
+            self.assertEqual(
+                {item.path for item in directory_manifest.artifacts},
+                set(ARTIFACT_NAMES) - {DIRECTORY_MANIFEST_NAME},
             )
 
         self.assertTrue(result["success"])

--- a/mcp_server/tests/test_server_policy.py
+++ b/mcp_server/tests/test_server_policy.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from multisim_mcp import server
+from multisim_mcp.workspace_manifest import read_directory_manifest
 
 
 class UnsafeToolGateTest(unittest.TestCase):
@@ -345,6 +346,10 @@ class VerificationAndSweepWorkflowTest(unittest.TestCase):
             data = (output / "data.csv").read_text(encoding="utf-8")
             self.assertIn("run_id,status,R1,vout", data)
             self.assertTrue((output / "runs" / "run-0002" / "result.raw").is_file())
+            directory_manifest = read_directory_manifest(output)
+            self.assertEqual(directory_manifest.directory_kind, "optimization")
+            self.assertEqual(directory_manifest.state, "succeeded")
+            self.assertEqual(directory_manifest.metadata["run_count"], 2)
 
     def test_plain_overwrite_does_not_retain_an_old_verification_verdict(self) -> None:
         def fake_schematic(*args: object, **kwargs: object) -> dict:

--- a/mcp_server/tests/test_workspace_manifest.py
+++ b/mcp_server/tests/test_workspace_manifest.py
@@ -1,0 +1,158 @@
+"""COM-free tests for versioned project/experiment/optimization manifests."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from multisim_mcp import __version__
+from multisim_mcp.workspace_manifest import (
+    DIRECTORY_MANIFEST_NAME,
+    read_directory_manifest,
+    verify_directory_manifest,
+    write_directory_manifest,
+)
+
+
+class DirectoryManifestTest(unittest.TestCase):
+    def test_round_trip_for_every_directory_kind(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            for kind in ("project", "experiment", "optimization"):
+                with self.subTest(kind=kind):
+                    root = base / kind
+                    nested = root / "artifacts"
+                    nested.mkdir(parents=True)
+                    (root / "design.json").write_text("{}\n", encoding="utf-8")
+                    (nested / "data.csv").write_text("x,y\n0,1\n", encoding="utf-8")
+
+                    written = write_directory_manifest(
+                        root,
+                        directory_kind=kind,
+                        entity_id=f"{kind}-fixture",
+                        state="succeeded",
+                        artifacts={
+                            "design.json": "design",
+                            "artifacts/data.csv": "simulation-data",
+                        },
+                        metadata={"backend": "fixture", "score": 1.0},
+                    )
+                    loaded = read_directory_manifest(root)
+
+                    self.assertEqual(loaded, written)
+                    self.assertEqual(loaded.schema_version, 1)
+                    self.assertEqual(loaded.directory_kind, kind)
+                    self.assertEqual(loaded.producer_version, __version__)
+                    self.assertEqual(
+                        [item.path for item in loaded.artifacts],
+                        ["artifacts/data.csv", "design.json"],
+                    )
+                    self.assertTrue(
+                        (root / DIRECTORY_MANIFEST_NAME)
+                        .read_text(encoding="utf-8")
+                        .endswith("\n")
+                    )
+
+    def test_rewrite_increments_revision_and_preserves_creation_time(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact = root / "design.json"
+            artifact.write_text('{"revision": 0}\n', encoding="utf-8")
+            first = write_directory_manifest(
+                root,
+                directory_kind="project",
+                entity_id="project-revision",
+                state="active",
+                artifacts={"design.json": "design"},
+            )
+            artifact.write_text('{"revision": 1}\n', encoding="utf-8")
+            second = write_directory_manifest(
+                root,
+                directory_kind="project",
+                entity_id="project-revision",
+                state="active",
+                artifacts={"design.json": "design"},
+            )
+
+            self.assertEqual(first.revision, 0)
+            self.assertEqual(second.revision, 1)
+            self.assertEqual(second.created_at, first.created_at)
+            self.assertEqual(second.manifest_id, first.manifest_id)
+            self.assertNotEqual(second.artifacts[0].sha256, first.artifacts[0].sha256)
+
+    def test_verification_detects_same_size_tampering(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact = root / "result.txt"
+            artifact.write_text("first", encoding="utf-8")
+            write_directory_manifest(
+                root,
+                directory_kind="experiment",
+                entity_id="experiment-tamper",
+                state="succeeded",
+                artifacts={"result.txt": "result"},
+            )
+            artifact.write_text("other", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "SHA-256 mismatch"):
+                read_directory_manifest(root)
+            loaded = read_directory_manifest(root, verify=False)
+            with self.assertRaisesRegex(ValueError, "SHA-256 mismatch"):
+                verify_directory_manifest(root, loaded)
+
+    def test_rejects_path_traversal_and_symlink_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as outside:
+            root = Path(tmp)
+            outside_file = Path(outside) / "outside.txt"
+            outside_file.write_text("outside", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "contained relative path"):
+                write_directory_manifest(
+                    root,
+                    directory_kind="project",
+                    entity_id="project-path",
+                    state="active",
+                    artifacts={"../outside.txt": "artifact"},
+                )
+            link = root / "linked.txt"
+            try:
+                link.symlink_to(outside_file)
+            except (OSError, NotImplementedError):
+                return
+            with self.assertRaisesRegex(ValueError, "must not traverse symlinks"):
+                write_directory_manifest(
+                    root,
+                    directory_kind="project",
+                    entity_id="project-link",
+                    state="active",
+                    artifacts={"linked.txt": "artifact"},
+                )
+
+    def test_reader_rejects_unknown_fields_and_wrong_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "result.txt").write_text("ok", encoding="utf-8")
+            write_directory_manifest(
+                root,
+                directory_kind="optimization",
+                entity_id="optimization-schema",
+                state="succeeded",
+                artifacts={"result.txt": "result"},
+            )
+            path = root / DIRECTORY_MANIFEST_NAME
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            payload["unexpected"] = True
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "unknown fields"):
+                read_directory_manifest(root)
+
+            payload.pop("unexpected")
+            payload["schema_version"] = 999
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "schema_version must be 1"):
+                read_directory_manifest(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/yxy050208/multisim-mcp",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "websiteUrl": "https://github.com/yxy050208/multisim-mcp",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "multisim-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tools/release_audit.py
+++ b/tools/release_audit.py
@@ -79,6 +79,8 @@ def audit() -> list[Finding]:
         "docs/PUBLISHING.md",
         "docs/MIGRATION_TO_1.0.md",
         "docs/RECOVERY.md",
+        "docs/WORKSPACE_MANIFESTS.md",
+        "docs/RELEASE_NOTES_v1.1.0.md",
         "docs/RELEASE_NOTES_v1.0.0.md",
         "docs/RELEASE_NOTES_v0.1.0-alpha.md",
         "docs/RELEASE_NOTES_v0.1.0-alpha.2.md",


### PR DESCRIPTION
## 概要

- 为项目、实验和参数扫描/优化目录增加严格版本化的 `directory.manifest.json`。
- 将目录清单纳入实验与扫描的原子发布事务，记录生命周期、修订号、产物大小和 SHA-256。
- 完成 EDA Core、DeepSeek/DeepSeek Harness 等现有未发布能力的 v1.1.0 版本整理。
- 同步 Python 包、MCP Registry 元数据和 Harness bundle 源码版本，并补充中英双语发布说明。

## 安全与兼容性

- 拒绝路径越界、反斜杠路径、符号链接、未知 schema 字段和内容篡改。
- 公共协议保持 55 tools、19 Resource templates、5 prompts。
- 公开包仍不包含 NI XML、`.ms14`、研究文件或本地实验产物。

## 验证

- 32 位 Python 3.12：271 项无 COM 测试通过。
- 64 位 Python 3.10：18 项目录清单、实验管线和任务引擎核心回归通过。
- MCP stdio 现代/兼容协议测试通过。
- DeepSeek Harness 兼容性、发布守卫和 npm dry-run 包边界通过。
- `multisim_mcp-1.1.0` wheel/sdist 构建及内容审计通过。
- 本次目录清单变更尚未执行新的真实 Multisim COM 回归；真实回归仍需本地已授权 Windows/Multisim 环境。

## 发布说明

这是草稿发布 PR。CI 全绿并完成复核前不应转正式、合并、打标签或发布 PyPI/MCP Registry。