### PR TITLE
docs: correct v1.1 publishing trigger

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -71,26 +71,48 @@ git diff --cached --check
 python tools/release_audit.py
 git commit -m "release: v1.1.0"
 git tag -a v1.1.0 -m "Multisim MCP v1.1.0"
+git show --no-patch --decorate v1.1.0
 ```
 
-推送、创建 GitHub Release 和上传附件应在再次检查暂存内容后手动执行。不要上传当前
-包含本地 XML 模板的开发 wheel。
+签注标签只用来锁定已审查源码，**推送标签本身不会触发 PyPI 发布**。
+`publish-pypi.yml` 只支持手动 `workflow_dispatch`；推送标签后，必须在该
+标签引用上手动运行工作流，并核对运行的 head SHA 与标签解引用提交一致。
+创建 GitHub Release 和上传附件也需要单独手动执行。不要上传包含本地
+XML 模板的开发 wheel。
 
-English: tag only after a final staged-file audit; never attach the local template wheel.
+English: an annotated tag pins reviewed source but does not publish anything.
+Manually dispatch `publish-pypi.yml` at that tag and verify the run SHA; never
+attach the local template wheel.
 
 ## 6. v1.1.0 发布顺序
 
 1. 推送发布提交并等待 `CI` 全部通过。
-2. 推送签注标签 `v1.1.0`，由 Trusted Publishing 工作流发布 PyPI 包。
-3. 核对 PyPI 文件 SHA-256，再创建 GitHub Release；附件只使用公开工作流构建的
-   code-only wheel/sdist，不使用本地模板开发包。
-4. 运行 MCP Registry 发布工作流，并确认 `io.github.yxy050208/multisim-mcp` 显示
+2. 创建并推送签注标签 `v1.1.0`，确认远端标签解引用到已通过 CI 的
+   `main` 合并提交。此操作不会自动发布 PyPI。
+3. 在标签引用上手动运行 Trusted Publishing，并等待成功：
+
+   ```powershell
+   gh workflow run publish-pypi.yml --repo yxy050208/multisim-mcp --ref v1.1.0
+   ```
+
+4. 核对 PyPI JSON API 中的版本、文件名和 SHA-256；再使用双语发布说明创建
+   GitHub Release。如果上传 wheel/sdist，只附加从 PyPI 下载并验证过的同一
+   份发布物，不使用本地模板开发包。
+5. 在同一标签引用上手动运行 MCP Registry 发布工作流，并确认
+   `io.github.yxy050208/multisim-mcp` 显示
    `1.1.0`。
-5. 核对 Glama、awesome-mcp-servers 等社区目录的仓库链接和徽章；目录更新不能先于
+
+   ```powershell
+   gh workflow run publish-mcp-registry.yml `
+     --repo yxy050208/multisim-mcp --ref v1.1.0
+   ```
+
+6. 核对 Glama、awesome-mcp-servers 等社区目录的仓库链接和徽章；目录更新不能先于
    可安装包和 Registry 元数据。
 
-English: publish in order—green CI, tag/PyPI, verified GitHub Release, MCP
-Registry, then community-directory metadata.
+English: publish in order—green CI, annotated tag, manual PyPI dispatch at the
+tag, verified GitHub Release, manual MCP Registry dispatch, then community
+directory metadata.
 
 ## 7. DeepSeek Harness npm bundle
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -93,8 +93,13 @@ adding an ignore rule does not remove a file that is already staged.
       in the local release audit.
 - [x] Push the release PR and wait for every public CI job to pass.
 - [x] Build and inspect the final wheel/sdist from the reviewed release commit.
-- [ ] Push annotated tag `v1.1.0` and verify Trusted Publishing on PyPI.
-- [ ] Publish matching MCP Registry metadata and GitHub Release artifacts.
+- [ ] Push annotated tag `v1.1.0` and verify it dereferences to the reviewed
+      `main` merge commit.
+- [ ] Manually dispatch `publish-pypi.yml` at `v1.1.0`, verify the workflow head
+      SHA, Trusted Publishing result, and PyPI distribution SHA-256 values.
+- [ ] Create the bilingual GitHub Release and attach only the exact verified
+      PyPI distributions when binary attachments are desired.
+- [ ] Publish matching MCP Registry metadata and verify official search results.
 - [ ] Re-check Glama and awesome-mcp-servers metadata after publication.
 
 ## DeepSeek Harness npm bundle 1.1.0


### PR DESCRIPTION
## 概要

- 修正 v1.1.0 发布指南中“推送标签会自动发布 PyPI”的错误描述。
- 明确签注标签只用于锁定已审查源码，PyPI 发布必须在该标签引用上手动运行 `publish-pypi.yml`。
- 补充 `gh workflow run` 的准确命令，以及工作流 head SHA、PyPI 文件名和 SHA-256 核验要求。
- 将标签、PyPI、GitHub Release 和 MCP Registry 拆分为独立发布门禁。

## 验证

- 相对 `main` 只包含提交 `0586b36`。
- 仅修改 `docs/PUBLISHING.md` 与 `docs/RELEASE_CHECKLIST.md`。
- `git diff --check` 通过。
- 本地发布审计通过：0 错误、0 警告。

这是发布前文档修正草稿；CI 全绿并复核后再转正式合并。不会由本 PR 自动创建标签或发布软件包。