### PR TITLE
docs: finalize v1.1.0 release copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 
 ## 开源发布状态
 
-`1.1.0` 是当前发布候选；发布后将与 PyPI 和
-`io.github.yxy050208/multisim-mcp` 官方 MCP Registry 条目同步。由本地 NI
+`1.1.0` 是当前稳定发行版；PyPI 包和
+`io.github.yxy050208/multisim-mcp` 官方 MCP Registry 条目使用同一版本号。由本地 NI
 样例提取的 XML 模板不属于
 MIT 代码授权范围，公开仓库默认不应包含这些文件。用户需要运行
 `tools/bootstrap_local_component_pack.py`，从自己已授权的 Multisim 安装生成本地模板包。

--- a/docs/RELEASE_NOTES_v1.1.0.md
+++ b/docs/RELEASE_NOTES_v1.1.0.md
@@ -54,7 +54,7 @@ MCP 前端也可运行在 64 位 Python，并通过 `MULTISIM_MCP_WORKER_PYTHON`
   3.10 上通过目录清单、实验管线和任务引擎核心回归。
 - `directory.manifest.json` 与正式实验 `manifest.json` 职责不同：前者约束目录级
   生命周期和全部产物完整性，后者继续保存实验复现语义。
-- 公开 CI 与最终 wheel/sdist 内容审计将在发布提交后再次执行；真实 Multisim 回归仍
+- 公开 CI 与最终 wheel/sdist 内容审计已通过；真实 Multisim 回归仍
   必须在安装并授权 NI 软件的本地 Windows 主机上完成。
 
 ## 升级说明


### PR DESCRIPTION
## 概要

- 将中文 README 的 v1.1.0 状态从发布候选改为当前稳定发行版。
- 将 v1.1.0 发布说明中的公共 CI 和最终 wheel/sdist 审计更新为已完成。

## 验证

- 仅修改两个发布文档。
- `git diff --check` 通过。
- 本地发布审计通过。

这是创建 v1.1.0 标签前的最终文案修正，不包含代码或工作流变更。