### PR TITLE
docs: complete v1.1.0 release checklist

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -93,14 +93,14 @@ adding an ignore rule does not remove a file that is already staged.
       in the local release audit.
 - [x] Push the release PR and wait for every public CI job to pass.
 - [x] Build and inspect the final wheel/sdist from the reviewed release commit.
-- [ ] Push annotated tag `v1.1.0` and verify it dereferences to the reviewed
+- [x] Push annotated tag `v1.1.0` and verify it dereferences to the reviewed
       `main` merge commit.
-- [ ] Manually dispatch `publish-pypi.yml` at `v1.1.0`, verify the workflow head
+- [x] Manually dispatch `publish-pypi.yml` at `v1.1.0`, verify the workflow head
       SHA, Trusted Publishing result, and PyPI distribution SHA-256 values.
-- [ ] Create the bilingual GitHub Release and attach only the exact verified
+- [x] Create the bilingual GitHub Release and attach only the exact verified
       PyPI distributions when binary attachments are desired.
-- [ ] Publish matching MCP Registry metadata and verify official search results.
-- [ ] Re-check Glama and awesome-mcp-servers metadata after publication.
+- [x] Publish matching MCP Registry metadata and verify official search results.
+- [x] Re-check Glama and awesome-mcp-servers metadata after publication.
 
 ## DeepSeek Harness npm bundle 1.1.0
 


### PR DESCRIPTION
## 完成内容 / Completion

- 将 v1.1.0 标签、PyPI Trusted Publishing、GitHub Release、MCP Registry 和社区目录复核标记为完成。
- 该 PR 仅更新发布清单，不改变 v1.1.0 标签或已发布制品。

## 验证 / Validation

- python tools/release_audit.py --json 通过；提交前唯一警告是预期的未提交清单改动。
- 官方 MCP Registry 已确认 1.1.0 为最新版本。
- Glama 页面与评分徽章可用，awesome-mcp-servers PR #11747 检查通过且可合并。