### PR TITLE
feat: prepare DeepSeek Harness npm plugin

### DIFF
--- a/.github/workflows/deepseek-harness-compatibility.yml
+++ b/.github/workflows/deepseek-harness-compatibility.yml
@@ -74,6 +74,12 @@ jobs:
         with:
           node-version: "24"
           package-manager-cache: false
+      - name: Install pinned pnpm
+        shell: pwsh
+        run: |
+          $packageManager = python -c "import json; print(json.load(open('compatibility/deepseek-harness.json', encoding='utf-8'))['upstream']['package_manager'])"
+          npm install --global $packageManager --ignore-scripts
+          pnpm --version
       - name: Install Multisim MCP
         run: python -m pip install ./mcp_server
       - name: Run isolated official Harness smoke

--- a/compatibility/deepseek-harness.json
+++ b/compatibility/deepseek-harness.json
@@ -1,17 +1,17 @@
 {
   "schema_version": 1,
-  "verified_date": "2026-08-18",
+  "verified_date": "2026-08-23",
   "status": "developer-preview",
   "upstream": {
     "repository": "https://github.com/deepseek-ai/deepseek-harness",
     "root_package_url": "https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/master/package.json",
     "dsh_cli_package_url": "https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/master/apps/cli/package.json",
     "mcp_client_package_url": "https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/master/packages/mcp/mcp-client/package.json",
-    "harness_version": "0.1.0-rc.7",
+    "harness_version": "0.1.1-rc.2",
     "dsh_cli_package": "@deepseek-ai/dsh",
-    "dsh_cli_version": "0.1.0-rc.7",
+    "dsh_cli_version": "0.1.1-rc.2",
     "mcp_client_package": "@deepseek-ai/dsh-mcp-client",
-    "mcp_client_version": "0.1.0-rc.7",
+    "mcp_client_version": "0.1.1-rc.2",
     "node_engine": "^22.19.0 || >=24.0.0",
     "package_manager": "pnpm@11.7.0",
     "mcp_sdk_range": "^1.12.0"

--- a/docs/DEEPSEEK_HARNESS.md
+++ b/docs/DEEPSEEK_HARNESS.md
@@ -9,9 +9,9 @@
 
 ## 当前兼容基线
 
-本说明核对日期为 2026-08-18。DeepSeek Harness 官方仓库仍标记为
+本说明核对日期为 2026-08-23。DeepSeek Harness 官方仓库仍标记为
 Developer Preview，并明确提示可能发生破坏性兼容变更。当前公开的
-`@deepseek-ai/dsh-mcp-client` 包版本为 `0.1.0-rc.7`。
+`@deepseek-ai/dsh-mcp-client` 已验证版本为 `0.1.1-rc.2`。
 
 已确认的 MCP Client 行为：
 
@@ -59,27 +59,28 @@ dsh --profile web --dump-config
 片段形状：
 
 ```yaml
-- id: "mcp-multisim"
-  name: "@deepseek-ai/dsh-mcp-client"
-  config:
-    serverName: "multisim"
-    transport: "stdio"
-    command: "C:\\path\\to\\python32\\python.exe"
-    args:
-      - "-m"
-      - "multisim_mcp.server"
-    env:
-      MULTISIM_MCP_ARTIFACT_EXPORT_DIR: "C:\\MultisimMcp\\exports"
-      MULTISIM_MCP_TEMPLATE_DIR: "C:\\MultisimMcp\\component-pack"
-      MULTISIM_MCP_TOOL_PROFILE: "experiment"
-      MULTISIM_MCP_WORKDIR: "C:\\msre_exp"
-    failOnStartupError: true
-    toolCallTimeoutMs: 120000
-    reconnect:
-      enabled: true
-      initialDelayMs: 500
-      maxDelayMs: 30000
-      maxAttempts: 10
+- insert:
+    - id: "mcp-multisim"
+      name: "@deepseek-ai/dsh-mcp-client"
+      config:
+        serverName: "multisim"
+        transport: "stdio"
+        command: "C:\\path\\to\\python32\\python.exe"
+        args:
+          - "-m"
+          - "multisim_mcp.server"
+        env:
+          MULTISIM_MCP_ARTIFACT_EXPORT_DIR: "C:\\MultisimMcp\\exports"
+          MULTISIM_MCP_TEMPLATE_DIR: "C:\\MultisimMcp\\component-pack"
+          MULTISIM_MCP_TOOL_PROFILE: "experiment"
+          MULTISIM_MCP_WORKDIR: "C:\\msre_exp"
+        failOnStartupError: true
+        toolCallTimeoutMs: 120000
+        reconnect:
+          enabled: true
+          initialDelayMs: 500
+          maxDelayMs: 30000
+          maxAttempts: 10
 ```
 
 Harness 的 `serverName` 当前只接受 1--32 个字母、数字、下划线或连字符；
@@ -164,17 +165,18 @@ Workflow seam 更适合由模型生成编排脚本和子代理的动态任务，
 仓库同时提供可独立安装的 bundle 源码：
 [`integrations/deepseek-harness`](../integrations/deepseek-harness)。它按照官方
 `dsh.bundle.patch` 约定声明 `cordis.patch.yml`，并把 MCP Client 依赖固定为
-`0.1.0-rc.7`。
+`0.1.1-rc.2`。
 
 ```powershell
 $env:MULTISIM_MCP_PYTHON = "C:\path\to\python32\python.exe"
-dsh plugin --profile web add .\integrations\deepseek-harness
+dsh plugin --profile web add "multisim-mcp-dsh-plugin@1.1.0"
 dsh --profile web --dump-config
 ```
 
-当前 bundle 可以从源码路径安装，但尚未发布到 npm。正式 npm 发布需要单独验证
-包名所有权、Trusted Publishing 和固定 Harness 版本，不能与 Python 包发布隐式
-绑定。配置只转发 `MULTISIM_MCP_*` 和 Python 运行选项，不会把
+首次发布完成前，维护者应使用 `npm pack` 生成的 `.tgz` 做隔离安装验证；不要把
+仓库相对目录当作最终用户安装方式。npm 发布需要单独验证包名所有权、Trusted
+Publishing 和固定 Harness 版本，不能与 Python 包发布隐式绑定。配置只转发
+`MULTISIM_MCP_*` 和 Python 运行选项，不会把
 `DEEPSEEK_API_KEY` 传入 MCP 子进程。
 首次发布、Registry 防抢注检查和后续 OIDC 暂存审批流程见
 [`DeepSeek Harness 插件 npm 发布手册`](DEEPSEEK_HARNESS_NPM_RELEASE.md)。
@@ -188,7 +190,7 @@ python tools/smoke_deepseek_harness.py --json
 ```
 
 该脚本使用临时 `DSH_HOME`，删除子进程环境中的 `DEEPSEEK_API_KEY`，强制关闭
-Harness 遥测，并固定运行 `@deepseek-ai/dsh@0.1.0-rc.7`。它先验证配置组合，再
+Harness 遥测，并固定运行 `@deepseek-ai/dsh@0.1.1-rc.2`。它先验证配置组合，再
 启动 Web profile；由于 MCP 配置启用了 `failOnStartupError`，只有官方 MCP Client
 成功连接、完成初始工具同步并且 Web 服务就绪才算通过。脚本不执行模型请求，也不
 需要 DeepSeek API Key。
@@ -219,7 +221,7 @@ PDF、图片、raw 和 `.ms14` 默认只返回元数据与本地引用，不应�
 ## 版本门禁与上游监控
 
 仓库使用 [`compatibility/deepseek-harness.json`](../compatibility/deepseek-harness.json)
-记录已验证基线。当前固定值包括 Harness 与 MCP Client `0.1.0-rc.7`、Node
+记录已验证基线。当前固定值包括 Harness 与 MCP Client `0.1.1-rc.2`、Node
 `^22.19.0 || >=24.0.0`、pnpm `11.7.0` 和上游 MCP SDK `^1.12.0`。
 
 维护者可以执行确定性的本地契约检查；该命令不访问网络：

--- a/docs/DEEPSEEK_HARNESS_NPM_RELEASE.md
+++ b/docs/DEEPSEEK_HARNESS_NPM_RELEASE.md
@@ -17,7 +17,7 @@
 
 ```powershell
 python tools/check_dsh_plugin_release.py `
-  --expected-version 1.0.0 `
+  --expected-version 1.1.0 `
   --check-registry `
   --json
 npm pack .\integrations\deepseek-harness --dry-run --json --ignore-scripts
@@ -26,7 +26,7 @@ npm pack .\integrations\deepseek-harness --dry-run --json --ignore-scripts
 发布守卫把 Registry 的 404 解释为“当前未被占用”，但这不是名称保留。首次发布前
 必须重新执行；如果 Registry 已出现同名包且其 repository 不是本项目，守卫会失败。
 
-## 首次发布 1.0.0
+## 首次发布 1.1.0
 
 npm 的 staged publishing 明确要求包已经存在，因此全新包不能使用
 `npm stage publish`。首次发布需要包所有者在可信本机完成，并使用账户 2FA：
@@ -35,7 +35,7 @@ npm 的 staged publishing 明确要求包已经存在，因此全新包不能使
 cd integrations\deepseek-harness
 npm login
 npm pack --json --ignore-scripts
-npm publish .\multisim-mcp-dsh-plugin-1.0.0.tgz --access public
+npm publish .\multisim-mcp-dsh-plugin-1.1.0.tgz --access public
 ```
 
 不要把一次性验证码写入脚本、文档或 shell 历史；让 npm 在交互提示中请求 2FA。
@@ -43,7 +43,7 @@ npm publish .\multisim-mcp-dsh-plugin-1.0.0.tgz --access public
 立即核对：
 
 ```powershell
-npm view multisim-mcp-dsh-plugin@1.0.0 `
+npm view multisim-mcp-dsh-plugin@1.1.0 `
   name version repository dist.integrity dist.shasum --json
 ```
 

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -3,18 +3,21 @@
 这是一个可独立安装的 Harness bundle。它把 Multisim MCP 注册为
 `mcp__multisim__*` 工具，并默认使用 `experiment` Tool Profile。
 
-## 本地安装
+## 安装
 
-先在 32 位 Python 中安装 `multisim-mcp`，然后设置该解释器路径：
+先在 32 位 Python 中安装与 bundle 同版本的 `multisim-mcp`，设置该解释器路径，
+再把固定版本的 bundle 加入 Harness profile：
 
 ```powershell
 $env:MULTISIM_MCP_PYTHON = "C:\path\to\python32\python.exe"
-dsh plugin --profile web add .\integrations\deepseek-harness
+& $env:MULTISIM_MCP_PYTHON -m pip install "multisim-mcp==1.1.0"
+dsh plugin --profile web add "multisim-mcp-dsh-plugin@1.1.0"
 dsh --profile web --dump-config
 ```
 
-在发布到 npm 后，可以把本地路径替换为
-`multisim-mcp-dsh-plugin@<version>`。当前源码包尚未发布到 npm。
+安装或升级 bundle 后应重新启动该 profile。发布前验证当前源码时，应先用
+`npm pack .\integrations\deepseek-harness --ignore-scripts` 生成 `.tgz`，再把该
+tarball 的绝对路径交给 `dsh plugin ... add`，以验证与最终发布相同的包边界。
 
 维护者发布前必须运行 Registry 与包边界守卫。首次发布需要本地 2FA；后续版本使用
 OIDC 暂存并由维护者 2FA 审批。完整步骤见
@@ -32,8 +35,9 @@ MCP 服务器命令在 agent 沙箱之外执行，应当只安装可信发布物
 
 ## English summary
 
-This package is an installable DeepSeek Harness bundle for Multisim MCP. Set
-`MULTISIM_MCP_PYTHON` to the installed 32-bit Python interpreter before adding
-the bundle to a Harness profile. Model credentials remain in Harness and are
-never forwarded to the MCP child process. Maintainer release instructions are
-in `docs/DEEPSEEK_HARNESS_NPM_RELEASE.md`.
+This package is an installable DeepSeek Harness bundle for Multisim MCP. Install
+it with `dsh plugin --profile web add multisim-mcp-dsh-plugin@1.1.0`, set
+`MULTISIM_MCP_PYTHON` to the 32-bit Python interpreter containing
+`multisim-mcp==1.1.0`, and restart the profile. Model credentials remain in
+Harness and are never forwarded to the MCP child process. Maintainer release
+instructions are in `docs/DEEPSEEK_HARNESS_NPM_RELEASE.md`.

--- a/integrations/deepseek-harness/cordis.patch.yml
+++ b/integrations/deepseek-harness/cordis.patch.yml
@@ -1,23 +1,24 @@
-- id: "mcp-multisim"
-  name: "@deepseek-ai/dsh-mcp-client"
-  config:
-    serverName: "multisim"
-    transport: "stdio"
-    command: !!js process.env.MULTISIM_MCP_PYTHON ?? "python"
-    args:
-      - "-m"
-      - "multisim_mcp.server"
-    env:
-      PYTHONUTF8: "1"
-      PYTHONUNBUFFERED: "1"
-      MULTISIM_MCP_TOOL_PROFILE: !!js process.env.MULTISIM_MCP_TOOL_PROFILE ?? "experiment"
-      MULTISIM_MCP_TEMPLATE_DIR: !!js process.env.MULTISIM_MCP_TEMPLATE_DIR ?? ""
-      MULTISIM_MCP_WORKDIR: !!js process.env.MULTISIM_MCP_WORKDIR ?? ""
-      MULTISIM_MCP_ARTIFACT_EXPORT_DIR: !!js process.env.MULTISIM_MCP_ARTIFACT_EXPORT_DIR ?? ""
-    failOnStartupError: true
-    toolCallTimeoutMs: 120000
-    reconnect:
-      enabled: true
-      initialDelayMs: 500
-      maxDelayMs: 30000
-      maxAttempts: 10
+- insert:
+    - id: "mcp-multisim"
+      name: "@deepseek-ai/dsh-mcp-client"
+      config:
+        serverName: "multisim"
+        transport: "stdio"
+        command: !!js process.env.MULTISIM_MCP_PYTHON ?? "python"
+        args:
+          - "-m"
+          - "multisim_mcp.server"
+        env:
+          PYTHONUTF8: "1"
+          PYTHONUNBUFFERED: "1"
+          MULTISIM_MCP_TOOL_PROFILE: !!js process.env.MULTISIM_MCP_TOOL_PROFILE ?? "experiment"
+          MULTISIM_MCP_TEMPLATE_DIR: !!js process.env.MULTISIM_MCP_TEMPLATE_DIR ?? ""
+          MULTISIM_MCP_WORKDIR: !!js process.env.MULTISIM_MCP_WORKDIR ?? ""
+          MULTISIM_MCP_ARTIFACT_EXPORT_DIR: !!js process.env.MULTISIM_MCP_ARTIFACT_EXPORT_DIR ?? ""
+        failOnStartupError: true
+        toolCallTimeoutMs: 120000
+        reconnect:
+          enabled: true
+          initialDelayMs: 500
+          maxDelayMs: 30000
+          maxAttempts: 10

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multisim-mcp-dsh-plugin",
   "version": "1.1.0",
-  "description": "DeepSeek Harness bundle for the Multisim MCP server",
+  "description": "DeepSeek Harness plugin for NI Multisim circuit generation, simulation, optimization, and lab reports via MCP",
   "license": "MIT",
   "type": "module",
   "publishConfig": {
@@ -17,9 +17,13 @@
   ],
   "keywords": [
     "dsh-plugin",
+    "deepseek",
     "deepseek-harness",
     "mcp",
     "multisim",
+    "ni-multisim",
+    "circuit-simulation",
+    "electronics",
     "eda"
   ],
   "repository": {
@@ -27,12 +31,12 @@
     "url": "git+https://github.com/yxy050208/multisim-mcp.git",
     "directory": "integrations/deepseek-harness"
   },
-  "homepage": "https://github.com/yxy050208/multisim-mcp#deepseek-harness",
+  "homepage": "https://github.com/yxy050208/multisim-mcp/tree/main/integrations/deepseek-harness",
   "bugs": {
     "url": "https://github.com/yxy050208/multisim-mcp/issues"
   },
   "dependencies": {
-    "@deepseek-ai/dsh-mcp-client": "0.1.0-rc.7"
+    "@deepseek-ai/dsh-mcp-client": "0.1.1-rc.2"
   },
   "dsh": {
     "bundle": {

--- a/mcp_server/multisim_mcp/cli.py
+++ b/mcp_server/multisim_mcp/cli.py
@@ -593,7 +593,7 @@ def _toml_string(value: str) -> str:
 def _render_deepseek_harness_config(
     server_name: str, spec: dict[str, Any]
 ) -> str:
-    """Render a Cordis plugin row for the official DeepSeek Harness MCP client."""
+    """Render a Cordis insert patch for the official Harness MCP client."""
     if not _HARNESS_SERVER_NAME_RE.fullmatch(server_name):
         raise ValueError(
             "DeepSeek Harness server name must be 1-32 characters and contain "
@@ -603,30 +603,31 @@ def _render_deepseek_harness_config(
     # JSON string literals are valid YAML scalars and avoid path escaping bugs on
     # Windows. Keep this fragment dependency-free so it works in the 32-bit host.
     lines = [
-        f"- id: {_toml_string(f'mcp-{server_name}')}",
-        '  name: "@deepseek-ai/dsh-mcp-client"',
-        "  config:",
-        f"    serverName: {_toml_string(server_name)}",
-        '    transport: "stdio"',
-        f"    command: {_toml_string(spec['command'])}",
-        "    args:",
+        "- insert:",
+        f"    - id: {_toml_string(f'mcp-{server_name}')}",
+        '      name: "@deepseek-ai/dsh-mcp-client"',
+        "      config:",
+        f"        serverName: {_toml_string(server_name)}",
+        '        transport: "stdio"',
+        f"        command: {_toml_string(spec['command'])}",
+        "        args:",
     ]
-    lines.extend(f"      - {_toml_string(item)}" for item in spec["args"])
+    lines.extend(f"          - {_toml_string(item)}" for item in spec["args"])
     if spec.get("env"):
-        lines.append("    env:")
+        lines.append("        env:")
         lines.extend(
-            f"      {key}: {_toml_string(value)}"
+            f"          {key}: {_toml_string(value)}"
             for key, value in sorted(spec["env"].items())
         )
     lines.extend(
         [
-            "    failOnStartupError: true",
-            "    toolCallTimeoutMs: 120000",
-            "    reconnect:",
-            "      enabled: true",
-            "      initialDelayMs: 500",
-            "      maxDelayMs: 30000",
-            "      maxAttempts: 10",
+            "        failOnStartupError: true",
+            "        toolCallTimeoutMs: 120000",
+            "        reconnect:",
+            "          enabled: true",
+            "          initialDelayMs: 500",
+            "          maxDelayMs: 30000",
+            "          maxAttempts: 10",
         ]
     )
     return "\n".join(lines) + "\n"

--- a/mcp_server/tests/test_cli.py
+++ b/mcp_server/tests/test_cli.py
@@ -223,7 +223,8 @@ class ConfigGeneratorTest(unittest.TestCase):
             tool_profile="experiment",
             artifact_export_dir=r"C:\MultisimMcp\exports",
         )
-        self.assertIn('- id: "mcp-multisim_lab"', content)
+        self.assertTrue(content.startswith("- insert:\n"))
+        self.assertIn('    - id: "mcp-multisim_lab"', content)
         self.assertIn('name: "@deepseek-ai/dsh-mcp-client"', content)
         self.assertIn('serverName: "multisim_lab"', content)
         self.assertIn('transport: "stdio"', content)

--- a/mcp_server/tests/test_harness_compatibility.py
+++ b/mcp_server/tests/test_harness_compatibility.py
@@ -22,13 +22,13 @@ def matching_upstream_loader(url: str, timeout: float) -> dict:
     if url.endswith("/packages/mcp/mcp-client/package.json"):
         return {
             "name": "@deepseek-ai/dsh-mcp-client",
-            "version": "0.1.0-rc.7",
+            "version": "0.1.1-rc.2",
             "dependencies": {"@modelcontextprotocol/sdk": "^1.12.0"},
         }
     if url.endswith("/apps/cli/package.json"):
-        return {"name": "@deepseek-ai/dsh", "version": "0.1.0-rc.7"}
+        return {"name": "@deepseek-ai/dsh", "version": "0.1.1-rc.2"}
     return {
-        "version": "0.1.0-rc.7",
+        "version": "0.1.1-rc.2",
         "packageManager": "pnpm@11.7.0",
         "engines": {"node": "^22.19.0 || >=24.0.0"},
     }

--- a/mcp_server/tests/test_harness_smoke_runner.py
+++ b/mcp_server/tests/test_harness_smoke_runner.py
@@ -20,18 +20,18 @@ SPEC.loader.exec_module(smoke)
 
 
 class HarnessSmokeRunnerTest(unittest.TestCase):
-    def test_npx_command_pins_package_version(self) -> None:
-        with patch.object(smoke.shutil, "which", return_value="npx"):
-            command = smoke._npx_command("@deepseek-ai/dsh", "0.1.0-rc.7", "--version")
+    def test_pnpm_command_pins_package_version(self) -> None:
+        with patch.object(smoke.shutil, "which", return_value="pnpm"):
+            command = smoke._pnpm_command("@deepseek-ai/dsh", "0.1.1-rc.2", "--version")
         self.assertEqual(
             command,
-            ["npx", "--yes", "@deepseek-ai/dsh@0.1.0-rc.7", "--version"],
+            ["pnpm", "dlx", "@deepseek-ai/dsh@0.1.1-rc.2", "--version"],
         )
 
-    def test_npx_command_fails_when_node_is_missing(self) -> None:
+    def test_pnpm_command_fails_when_pnpm_is_missing(self) -> None:
         with patch.object(smoke.shutil, "which", return_value=None):
-            with self.assertRaisesRegex(RuntimeError, "npx is unavailable"):
-                smoke._npx_command("@deepseek-ai/dsh", "0.1.0-rc.7", "--version")
+            with self.assertRaisesRegex(RuntimeError, "pnpm is unavailable"):
+                smoke._pnpm_command("@deepseek-ai/dsh", "0.1.1-rc.2", "--version")
 
     def test_process_group_options_match_platform(self) -> None:
         options = smoke._process_group_options()

--- a/tools/check_deepseek_harness_compat.py
+++ b/tools/check_deepseek_harness_compat.py
@@ -204,6 +204,8 @@ def check_local_contract(repo_root: Path, manifest: dict[str, Any]) -> list[dict
                 )
             )
         required_patch_fragments = (
+            "- insert:",
+            '- id: "mcp-multisim"',
             'name: "@deepseek-ai/dsh-mcp-client"',
             'serverName: "multisim"',
             'transport: "stdio"',
@@ -217,6 +219,17 @@ def check_local_contract(repo_root: Path, manifest: dict[str, Any]) -> list[dict
                         "error", "bundle-patch", f"missing fragment: {fragment}"
                     )
                 )
+        if not re.search(
+            r'(?m)^- insert:\s*\r?\n\s+- id: "mcp-multisim"\s*$',
+            bundle_patch,
+        ):
+            findings.append(
+                _finding(
+                    "error",
+                    "bundle-patch",
+                    "mcp-multisim must be nested under an insert operation",
+                )
+            )
         if "DEEPSEEK_API_KEY" in bundle_patch:
             findings.append(
                 _finding(

--- a/tools/smoke_deepseek_harness.py
+++ b/tools/smoke_deepseek_harness.py
@@ -34,11 +34,14 @@ def _tail(path: Path, limit: int = 8000) -> str:
     return text[-limit:]
 
 
-def _npx_command(package: str, version: str, *args: str) -> list[str]:
-    executable = shutil.which("npx")
+def _pnpm_command(package: str, version: str, *args: str) -> list[str]:
+    executable = shutil.which("pnpm")
     if not executable:
-        raise RuntimeError("npx is unavailable; install Node.js 22.19+ or 24+")
-    return [executable, "--yes", f"{package}@{version}", *args]
+        raise RuntimeError(
+            "pnpm is unavailable; install the packageManager version pinned "
+            "by compatibility/deepseek-harness.json"
+        )
+    return [executable, "dlx", f"{package}@{version}", *args]
 
 
 def _process_group_options() -> dict[str, Any]:
@@ -105,6 +108,8 @@ def _run_bounded(
         cwd=cwd,
         env=env,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         **_process_group_options(),
@@ -164,7 +169,7 @@ def run_smoke(
         environment.pop("DEEPSEEK_API_KEY", None)
 
         version_check = _run_bounded(
-            _npx_command(package, version, "--version"),
+            _pnpm_command(package, version, "--version"),
             cwd=workspace,
             env=environment,
             timeout=install_timeout,
@@ -181,7 +186,7 @@ def run_smoke(
             )
 
         dump = _run_bounded(
-            _npx_command(
+            _pnpm_command(
                 package,
                 version,
                 "web",
@@ -203,12 +208,13 @@ def run_smoke(
                 raise RuntimeError(f"composed dsh config is missing {fragment!r}")
 
         port = _free_loopback_port()
-        command = _npx_command(
+        command = _pnpm_command(
             package,
             version,
             "web",
             "--patch",
             str(patch),
+            "--no-open",
             "--port",
             str(port),
         )


### PR DESCRIPTION
## 概要

- 将 DeepSeek Harness 基线升级到 `0.1.1-rc.2`
- 修复 Cordis 新插件必须使用 `insert:` 的真实兼容性问题
- 为首次发布 `multisim-mcp-dsh-plugin@1.1.0` 补齐 npm 元数据、中英双语说明与发布门禁
- 将官方 Harness 冒烟切换到固定 pnpm，并修复 Windows UTF-8 输出解码
- 增加配置生成器与静态检查，防止补丁被 DSH 静默忽略

## 验证

- 271 个 COM-free 单元测试通过
- 严格上游契约检查通过（Harness / CLI / MCP client `0.1.1-rc.2`）
- 官方 DSH 端到端启动通过：配置合成、MCP 初始连接、工具同步、Web HTTP 200
- npm Registry 包名仍未占用
- npm tarball 仅包含 LICENSE、README.md、cordis.patch.yml、package.json
- 从实际 `.tgz` 隔离安装后，DSH 自动加载 `mcp-multisim`

## 发布说明

首次 npm 发布仍需维护者本机 `npm login` 与 2FA；本 PR 不上传 npm 包，也不保存 token。