### PR TITLE
docs: record DeepSeek Harness npm release

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,7 @@
 # Multisim MCP + Skills
 
 [![Glama MCP server score](https://glama.ai/mcp/servers/yxy050208/multisim-mcp/badges/score.svg)](https://glama.ai/mcp/servers/yxy050208/multisim-mcp)
+[![DeepSeek Harness npm bundle](https://img.shields.io/npm/v/multisim-mcp-dsh-plugin.svg?label=dsh%20plugin)](https://www.npmjs.com/package/multisim-mcp-dsh-plugin)
 
 [中文](README.md) | [English (current)](README.en.md)
 
@@ -242,11 +243,13 @@ or safely parsed SPICE; it cannot simulate or mutate a design. See the
 [read-only diagnosis guide](docs/READ_ONLY_EDA_DIAGNOSIS.md).
 Repository maintainers can validate the pinned local Harness contract with
 `python tools/check_deepseek_harness_compat.py --json`.
-An independently installable source bundle is available under
-[`integrations/deepseek-harness`](integrations/deepseek-harness); it has not yet
-been published to npm. Maintainers should follow the
-[npm release guide](docs/DEEPSEEK_HARNESS_NPM_RELEASE.md) for the first 2FA
-publication and later OIDC-staged updates.
+The independently installable bundle under
+[`integrations/deepseek-harness`](integrations/deepseek-harness) is published as
+[`multisim-mcp-dsh-plugin@1.1.0`](https://www.npmjs.com/package/multisim-mcp-dsh-plugin).
+Install the pinned release with
+`dsh plugin --profile web add multisim-mcp-dsh-plugin@1.1.0`. Maintainers should
+follow the [npm release guide](docs/DEEPSEEK_HARNESS_NPM_RELEASE.md) for
+post-publication Trusted Publishing and later OIDC-staged updates.
 
 Manual MCP client configuration:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Multisim MCP + Skills
 
 [![Glama MCP server score](https://glama.ai/mcp/servers/yxy050208/multisim-mcp/badges/score.svg)](https://glama.ai/mcp/servers/yxy050208/multisim-mcp)
+[![DeepSeek Harness npm bundle](https://img.shields.io/npm/v/multisim-mcp-dsh-plugin.svg?label=dsh%20plugin)](https://www.npmjs.com/package/multisim-mcp-dsh-plugin)
 
 [中文（当前）](README.md) | [English](README.en.md)
 
@@ -15,6 +16,7 @@
 
 [PyPI 安装包](https://pypi.org/project/multisim-mcp/) ·
 [官方 MCP Registry 条目](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.yxy050208%2Fmultisim-mcp) ·
+[DeepSeek Harness npm 插件](https://www.npmjs.com/package/multisim-mcp-dsh-plugin) ·
 [GitHub Release](https://github.com/yxy050208/multisim-mcp/releases/tag/v1.1.0)
 
 ## 开源发布状态
@@ -253,8 +255,10 @@ OpenAI-compatible 服务；默认只预览，`--apply` 才原子写入，`--prob
 Harness 本地契约；版本与上游检查细节见适配说明。
 需要把集成作为 Harness 插件安装时，可使用
 [`integrations/deepseek-harness`](integrations/deepseek-harness) 中的独立 bundle；
-它目前支持本地源码安装，尚未发布到 npm。维护者的首次 2FA 发布与后续 OIDC
-暂存流程见 [`npm 发布手册`](docs/DEEPSEEK_HARNESS_NPM_RELEASE.md)。
+`multisim-mcp-dsh-plugin@1.1.0` 已公开发布到 npm。固定版本安装命令为
+`dsh plugin --profile web add multisim-mcp-dsh-plugin@1.1.0`；维护者的发布后
+Trusted Publishing 与后续 OIDC 暂存流程见
+[`npm 发布手册`](docs/DEEPSEEK_HARNESS_NPM_RELEASE.md)。
 
 手工 MCP 客户端配置：
 

--- a/docs/DEEPSEEK_HARNESS.md
+++ b/docs/DEEPSEEK_HARNESS.md
@@ -173,12 +173,12 @@ dsh plugin --profile web add "multisim-mcp-dsh-plugin@1.1.0"
 dsh --profile web --dump-config
 ```
 
-首次发布完成前，维护者应使用 `npm pack` 生成的 `.tgz` 做隔离安装验证；不要把
-仓库相对目录当作最终用户安装方式。npm 发布需要单独验证包名所有权、Trusted
-Publishing 和固定 Harness 版本，不能与 Python 包发布隐式绑定。配置只转发
-`MULTISIM_MCP_*` 和 Python 运行选项，不会把
+`multisim-mcp-dsh-plugin@1.1.0` 已于 2026-08-23 公开发布到 npm。发布后已从
+Registry 包名完成全新 profile 安装，验证 Cordis 组合、MCP 子进程启动和 Web
+HTTP 200。npm 发布仍与 Python 包独立；配置只转发 `MULTISIM_MCP_*` 和 Python
+运行选项，不会把
 `DEEPSEEK_API_KEY` 传入 MCP 子进程。
-首次发布、Registry 防抢注检查和后续 OIDC 暂存审批流程见
+Registry 归属检查和后续 OIDC 暂存审批流程见
 [`DeepSeek Harness 插件 npm 发布手册`](DEEPSEEK_HARNESS_NPM_RELEASE.md)。
 
 ## 官方 dsh 端到端烟雾测试

--- a/docs/DEEPSEEK_HARNESS_NPM_RELEASE.md
+++ b/docs/DEEPSEEK_HARNESS_NPM_RELEASE.md
@@ -4,6 +4,11 @@
 包、MCP Registry 和该 bundle 是三个独立发布物；版本当前保持同步，但不能由同一个
 上传步骤隐式联动。
 
+> 发布状态：`multisim-mcp-dsh-plugin@1.1.0` 已于 2026-08-23 使用维护者 2FA
+> 首次公开发布。Registry integrity 为
+> `sha512-tdZ2d3tw5lxe7Dg5aCTEZekw8tIb0jqk3d8j8o39BylKrEs+aPOiuXka1mNT4pYVLLdkzAZ6gEiRUHzf0pMEqQ==`。
+> 发布后已从 npm 包名完成隔离安装、Cordis 合成、MCP 启动和 Web HTTP 200 验证。
+
 ## 安全边界
 
 - 包名固定为 `multisim-mcp-dsh-plugin`，发布前必须再次查询 Registry；
@@ -79,9 +84,9 @@ Publisher；工作流文件名和 Environment 名必须完全一致。
 
 ## English summary
 
-The first publication must be performed interactively with maintainer 2FA,
-because npm does not allow staged publishing for a brand-new package. After the
-package exists, configure `publish-dsh-plugin.yml` as a stage-only trusted
-publisher bound to the `npm` GitHub Environment. Future CI runs use short-lived
-OIDC credentials to stage, while a maintainer still reviews and approves every
-release with 2FA. No long-lived npm publish token is stored in the repository.
+Version `1.1.0` was published interactively with maintainer 2FA on 2026-08-23
+and verified through a clean Registry install and live Harness startup. Configure
+`publish-dsh-plugin.yml` as a stage-only trusted publisher bound to the `npm`
+GitHub Environment. Future CI runs use short-lived OIDC credentials to stage,
+while a maintainer still reviews and approves every release with 2FA. No
+long-lived npm publish token is stored in the repository.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -108,9 +108,12 @@ adding an ignore rule does not remove a file that is already staged.
 - [x] Restrict the npm tarball to four reviewed files.
 - [x] Add a Registry ownership/version guard with unit tests.
 - [x] Add verify-only and stage-existing GitHub Actions paths.
-- [ ] Re-run the Registry guard immediately before the first publication.
-- [ ] Publish `multisim-mcp-dsh-plugin@1.1.0` interactively with maintainer 2FA.
+- [x] Re-run the Registry guard immediately before the first publication.
+- [x] Publish `multisim-mcp-dsh-plugin@1.1.0` interactively with maintainer 2FA.
+- [x] Verify public Registry metadata, integrity, clean profile installation,
+      Cordis composition, MCP startup, and Web HTTP 200.
 - [ ] Configure `publish-dsh-plugin.yml` as a stage-only npm Trusted Publisher.
-- [ ] Protect the GitHub `npm` Environment with required reviewers.
+- [x] Protect the GitHub `npm` Environment with `yxy050208` as a required
+      reviewer.
 - [ ] Disallow traditional publish tokens and verify package provenance on the
       next staged release.

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -233,8 +233,11 @@ files by default, and only replaces them when `--force` is explicit.
 Source-tree maintainers can run `python tools/check_deepseek_harness_compat.py
 --json` from the repository root to validate the pinned Harness contract.
 The independently installable Harness bundle lives in
-[`integrations/deepseek-harness`](../integrations/deepseek-harness) and currently
-supports local source installation; it is not yet published to npm.
+[`integrations/deepseek-harness`](../integrations/deepseek-harness) and is
+published as
+[`multisim-mcp-dsh-plugin@1.1.0`](https://www.npmjs.com/package/multisim-mcp-dsh-plugin).
+Install it with
+`dsh plugin --profile web add multisim-mcp-dsh-plugin@1.1.0`.
 The separate `configure` command prepares model-provider settings for the future
 workbench. It never copies credential values into its versioned JSON file or the
 MCP child process, and it performs network I/O only with explicit `--probe`.


### PR DESCRIPTION
## Summary

- record the public `multisim-mcp-dsh-plugin@1.1.0` npm release
- add npm links, badge, and published installation commands to Chinese and English documentation
- record a verified clean registry install and real DeepSeek Harness/MCP startup
- record the protected GitHub `npm` Environment; Trusted Publisher remains the final account-side hardening step

## Verification

- `npm view multisim-mcp-dsh-plugin@1.1.0`
- clean install with `dsh plugin --profile web add multisim-mcp-dsh-plugin@1.1.0`
- DeepSeek Harness web profile returned HTTP 200 with `mcp-multisim` loaded
- Git tree exactly matches the reviewed local documentation commit